### PR TITLE
security: harden URL config fetch against MITM

### DIFF
--- a/src/dotbrowser/_base/orchestrator.py
+++ b/src/dotbrowser/_base/orchestrator.py
@@ -30,6 +30,9 @@ else:
 from dotbrowser._base.utils import Plan, find_preferences, load_prefs, write_atomic
 
 
+_MAX_URL_CONFIG_BYTES = 256 * 1024
+
+
 def _load_toml(path: Path) -> dict:
     with path.open("rb") as f:
         return tomllib.load(f)
@@ -39,25 +42,63 @@ def _looks_like_url(value: object) -> bool:
     return isinstance(value, str) and value.startswith(("http://", "https://"))
 
 
-def _load_toml_from_url(url: str) -> dict:
+def _load_toml_from_url(
+    url: str,
+    *,
+    allow_http: bool = False,
+    expect_sha256: str | None = None,
+) -> dict:
+    if url.startswith("http://") and not allow_http:
+        sys.exit(
+            f"error: refusing to fetch config over plain http: {url}\n"
+            "  HTTP responses can be modified by anyone on the network and "
+            "could inject\n"
+            "  a malicious [pwa] table that runs through sudo. Use https:// "
+            "or pass\n"
+            "  --allow-http to opt in (e.g. for a trusted intranet host)."
+        )
     try:
         with urllib.request.urlopen(url, timeout=10) as resp:
-            data = resp.read()
+            data = resp.read(_MAX_URL_CONFIG_BYTES + 1)
     except urllib.error.URLError as e:
         sys.exit(f"error: failed to fetch {url}: {e.reason}")
+    if len(data) > _MAX_URL_CONFIG_BYTES:
+        sys.exit(
+            f"error: config from {url} exceeds the {_MAX_URL_CONFIG_BYTES}-byte "
+            f"limit. If this is intentional, fetch the file locally and pass "
+            f"the path instead."
+        )
+    digest = hashlib.sha256(data).hexdigest()
     print(f"source: {url}")
     print(f"  size:   {len(data)} bytes")
-    print(f"  sha256: {hashlib.sha256(data).hexdigest()}")
+    print(f"  sha256: {digest}")
+    if expect_sha256 is not None:
+        want = expect_sha256.strip().lower()
+        if digest != want:
+            sys.exit(
+                f"error: sha256 mismatch for {url}\n"
+                f"  expected: {want}\n"
+                f"  got:      {digest}\n"
+                "  refusing to apply -- the file may have changed or been "
+                "tampered with."
+            )
     try:
         return tomllib.loads(data.decode("utf-8"))
     except (tomllib.TOMLDecodeError, UnicodeDecodeError) as e:
         sys.exit(f"error: failed to parse TOML from {url}: {e}")
 
 
-def load_toml_source(src: str) -> dict:
+def load_toml_source(
+    src: str,
+    *,
+    allow_http: bool = False,
+    expect_sha256: str | None = None,
+) -> dict:
     """Load a TOML config from a file path or URL."""
     if _looks_like_url(src):
-        return _load_toml_from_url(src)
+        return _load_toml_from_url(
+            src, allow_http=allow_http, expect_sha256=expect_sha256
+        )
     return _load_toml(Path(src))
 
 
@@ -79,7 +120,11 @@ def cmd_apply(
     module's function names takes effect.
     """
     prefs_path = find_preferences(args.profile_root, args.profile)
-    doc = load_toml_source(args.config)
+    doc = load_toml_source(
+        args.config,
+        allow_http=getattr(args, "allow_http", False),
+        expect_sha256=getattr(args, "expect_sha256", None),
+    )
     if not isinstance(doc, dict):
         sys.exit("error: TOML root must be a table")
 
@@ -275,7 +320,22 @@ def register_browser(
     )
     a.add_argument(
         "config",
-        help="path to a local TOML file, or http(s):// URL to fetch one",
+        help="path to a local TOML file, or https:// URL to fetch one "
+        "(http:// is refused unless --allow-http is set)",
+    )
+    a.add_argument(
+        "--expect-sha256",
+        metavar="HEX",
+        default=None,
+        help="when fetching a URL, refuse to apply unless the response sha256 "
+        "matches this hex digest",
+    )
+    a.add_argument(
+        "--allow-http",
+        action="store_true",
+        help="allow fetching configs over plain http:// (NOT recommended; the "
+        "response can be modified in transit and a malicious [pwa] table "
+        "would run through sudo)",
     )
     a.add_argument("-n", "--dry-run", action="store_true")
     a.add_argument(

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -1,0 +1,139 @@
+"""URL config fetch hardening: HTTPS-only, sha256 pin, size cap.
+
+Covers ``_base/orchestrator._load_toml_from_url`` and ``load_toml_source``.
+The real network is never hit -- ``urllib.request.urlopen`` is
+monkeypatched to return a canned BytesIO response so the tests are
+deterministic and offline.
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+
+import pytest
+
+from dotbrowser._base import orchestrator as orch
+
+
+_OK_TOML = b'[settings]\n"foo.bar" = true\n'
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes):
+        self._buf = io.BytesIO(data)
+
+    def read(self, n: int = -1) -> bytes:
+        return self._buf.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _stub_urlopen(monkeypatch: pytest.MonkeyPatch, data: bytes) -> None:
+    def fake(url, timeout=10):
+        return _FakeResponse(data)
+
+    monkeypatch.setattr(orch.urllib.request, "urlopen", fake)
+
+
+def test_http_refused_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The url scheme guard fires before urlopen is called."""
+    def boom(url, timeout=10):
+        raise AssertionError("urlopen should not be called for refused http")
+
+    monkeypatch.setattr(orch.urllib.request, "urlopen", boom)
+    with pytest.raises(SystemExit, match="refusing to fetch config over plain http"):
+        orch._load_toml_from_url("http://example.com/cfg.toml")
+
+
+def test_http_allowed_with_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_urlopen(monkeypatch, _OK_TOML)
+    doc = orch._load_toml_from_url(
+        "http://example.com/cfg.toml", allow_http=True
+    )
+    assert doc == {"settings": {"foo.bar": True}}
+
+
+def test_https_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_urlopen(monkeypatch, _OK_TOML)
+    doc = orch._load_toml_from_url("https://example.com/cfg.toml")
+    assert doc == {"settings": {"foo.bar": True}}
+
+
+def test_sha256_match_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_urlopen(monkeypatch, _OK_TOML)
+    digest = hashlib.sha256(_OK_TOML).hexdigest()
+    doc = orch._load_toml_from_url(
+        "https://example.com/cfg.toml", expect_sha256=digest
+    )
+    assert doc == {"settings": {"foo.bar": True}}
+
+
+def test_sha256_match_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_urlopen(monkeypatch, _OK_TOML)
+    digest = hashlib.sha256(_OK_TOML).hexdigest().upper()
+    doc = orch._load_toml_from_url(
+        "https://example.com/cfg.toml", expect_sha256=digest
+    )
+    assert doc == {"settings": {"foo.bar": True}}
+
+
+def test_sha256_mismatch_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_urlopen(monkeypatch, _OK_TOML)
+    with pytest.raises(SystemExit, match="sha256 mismatch"):
+        orch._load_toml_from_url(
+            "https://example.com/cfg.toml",
+            expect_sha256="0" * 64,
+        )
+
+
+def test_size_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A response larger than _MAX_URL_CONFIG_BYTES must be refused.
+
+    The implementation reads MAX+1 bytes and complains if it got more
+    than MAX -- so the response only needs to be MAX+1 bytes long.
+    """
+    big = b"a" * (orch._MAX_URL_CONFIG_BYTES + 1)
+    _stub_urlopen(monkeypatch, big)
+    with pytest.raises(SystemExit, match="exceeds"):
+        orch._load_toml_from_url("https://example.com/big.toml")
+
+
+def test_size_cap_at_limit_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A response exactly at the limit (and parseable) is fine."""
+    payload = b"# pad\n" * 1000 + _OK_TOML
+    payload = payload[: orch._MAX_URL_CONFIG_BYTES]
+    _stub_urlopen(monkeypatch, payload)
+    # It just needs to not raise the size error; TOML parse may or may
+    # not succeed depending on truncation, so we tolerate either branch.
+    try:
+        orch._load_toml_from_url("https://example.com/edge.toml")
+    except SystemExit as e:
+        assert "exceeds" not in str(e), "size error fired at exactly the limit"
+
+
+def test_load_toml_source_passes_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """load_toml_source must forward allow_http / expect_sha256 to the
+    URL loader (regression guard if the keyword names drift)."""
+    captured: dict = {}
+
+    def fake_url_loader(url, *, allow_http, expect_sha256):
+        captured["url"] = url
+        captured["allow_http"] = allow_http
+        captured["expect_sha256"] = expect_sha256
+        return {}
+
+    monkeypatch.setattr(orch, "_load_toml_from_url", fake_url_loader)
+    orch.load_toml_source(
+        "https://example.com/x.toml",
+        allow_http=True,
+        expect_sha256="abc",
+    )
+    assert captured == {
+        "url": "https://example.com/x.toml",
+        "allow_http": True,
+        "expect_sha256": "abc",
+    }


### PR DESCRIPTION
Closes #12.

## Summary
- Refuse `http://` configs unless `--allow-http` is passed.
- Add `--expect-sha256=<hex>` to pin a known-good digest.
- Cap fetched responses at 256 KB so a hostile server can't OOM the process.

The fetched-bytes sha256 was already printed; this PR makes it actionable instead of decorative.

## Test plan
- [x] `pytest tests/test_url_config.py -q` — 9 new tests cover http reject/allow, https flow, sha256 match/mismatch (case-insensitive), size cap, and `load_toml_source` flag forwarding.
- [x] Full suite: 158 passed (149 prior + 9 new).
- [ ] Manual: fetch a real https config to confirm the new flags surface in `--help`.