### PR TITLE
errors: clean exits for malformed TOML and missing sudo

### DIFF
--- a/src/dotbrowser/_base/orchestrator.py
+++ b/src/dotbrowser/_base/orchestrator.py
@@ -34,8 +34,13 @@ _MAX_URL_CONFIG_BYTES = 256 * 1024
 
 
 def _load_toml(path: Path) -> dict:
-    with path.open("rb") as f:
-        return tomllib.load(f)
+    try:
+        with path.open("rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        sys.exit(f"error: config file not found: {path}")
+    except tomllib.TOMLDecodeError as e:
+        sys.exit(f"error: invalid TOML at {path}: {e}")
 
 
 def _looks_like_url(value: object) -> bool:
@@ -168,19 +173,20 @@ def cmd_apply(
                     "command prompt or PowerShell."
                 )
         else:
-            cached = subprocess.run(
-                ["sudo", "-n", "true"], stderr=subprocess.DEVNULL
-            ).returncode == 0
-            if not cached:
-                try:
+            try:
+                cached = subprocess.run(
+                    ["sudo", "-n", "true"], stderr=subprocess.DEVNULL
+                ).returncode == 0
+                if not cached:
                     subprocess.run(["sudo", "-v"], check=True)
-                except (subprocess.CalledProcessError, FileNotFoundError) as e:
-                    sys.exit(
-                        "error: [pwa] requires sudo to write the managed-policy "
-                        f"file but auth failed: {e}\n"
-                        "(if running non-interactively, run `sudo -v` from a "
-                        "terminal first to cache credentials)"
-                    )
+            except (subprocess.CalledProcessError, FileNotFoundError) as e:
+                sys.exit(
+                    "error: [pwa] requires sudo to write the managed-policy "
+                    f"file but auth failed: {e}\n"
+                    "(if sudo isn't installed, [pwa] isn't supported on this "
+                    "platform; if running non-interactively, run `sudo -v` "
+                    "from a terminal first to cache credentials)"
+                )
 
     saved_cmdline: list[str] | None = None
     was_killed = False

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,147 @@
+"""Clean-error-message regression tests.
+
+Covers:
+- ``_load_toml`` exits cleanly on malformed local TOML and missing files
+  (issue #13).
+- The sudo preflight in ``cmd_apply`` exits cleanly on systems without
+  sudo, instead of letting ``FileNotFoundError`` bubble (issue #14).
+
+All tests are pure-logic and run offline -- no Brave install required.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from dotbrowser._base import orchestrator as orch
+from dotbrowser._base.utils import Plan
+
+
+# ---------------------------------------------------------------------------
+# #13: TOML parse / file errors
+# ---------------------------------------------------------------------------
+
+
+def test_load_toml_malformed_file_exits_cleanly(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.toml"
+    bad.write_text("not = valid = toml\n")
+    with pytest.raises(SystemExit, match=r"invalid TOML at .*bad\.toml"):
+        orch._load_toml(bad)
+
+
+def test_load_toml_missing_file_exits_cleanly(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.toml"
+    with pytest.raises(SystemExit, match="config file not found"):
+        orch._load_toml(missing)
+
+
+def test_load_toml_well_formed_passes(tmp_path: Path) -> None:
+    good = tmp_path / "good.toml"
+    good.write_text('[settings]\n"foo.bar" = true\n')
+    assert orch._load_toml(good) == {"settings": {"foo.bar": True}}
+
+
+# ---------------------------------------------------------------------------
+# #14: sudo preflight on systems without sudo
+# ---------------------------------------------------------------------------
+
+
+def _build_pwa_only_plans(_prefs_path, _prefs, _doc):
+    """Stand-in build_plans_fn that yields a single non-empty pwa-shaped
+    plan -- enough to make the orchestrator hit the sudo preflight."""
+    return [
+        Plan(
+            namespace="pwa",
+            diff_lines=["  + https://example.com/"],
+            apply_fn=lambda _: None,
+            verify_fn=lambda _: None,
+            external_apply_fn=lambda: None,
+        )
+    ]
+
+
+def _make_args(profile_root: Path, config: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        profile_root=profile_root,
+        profile="Default",
+        config=str(config),
+        dry_run=False,
+        kill_browser=False,
+        allow_http=False,
+        expect_sha256=None,
+    )
+
+
+def test_sudo_preflight_handles_missing_sudo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a system where ``sudo`` is not on PATH, the cached check
+    raises FileNotFoundError. The orchestrator must surface a clean
+    error, not a traceback.
+    """
+    if Path("/").drive:
+        pytest.skip("Linux/macOS-only path; Windows uses IsUserAnAdmin")
+
+    profile = tmp_path / "Default"
+    profile.mkdir()
+    (profile / "Preferences").write_text("{}")
+
+    cfg = tmp_path / "x.toml"
+    cfg.write_text('[pwa]\nurls = ["https://example.com/"]\n')
+
+    def boom(cmd, *args, **kwargs):
+        # Both the cached `-n true` and the interactive `-v` go through
+        # subprocess.run; either being unavailable is the thing we test.
+        raise FileNotFoundError(2, "No such file or directory: 'sudo'")
+
+    monkeypatch.setattr(orch.subprocess, "run", boom)
+
+    with pytest.raises(SystemExit, match="auth failed"):
+        orch.cmd_apply(
+            _make_args(tmp_path, cfg),
+            display_name="Brave",
+            running_fn=lambda: False,
+            pids_fn=lambda: [],
+            find_cmdline_fn=lambda: None,
+            kill_fn=lambda: None,
+            restart_fn=lambda _cmd: [],
+            build_plans_fn=_build_pwa_only_plans,
+        )
+
+
+def test_sudo_preflight_handles_calledprocesserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the interactive `sudo -v` fails (user dismisses the prompt or
+    is not in sudoers), the same clean error must fire."""
+    import subprocess as sp
+
+    profile = tmp_path / "Default"
+    profile.mkdir()
+    (profile / "Preferences").write_text("{}")
+
+    cfg = tmp_path / "x.toml"
+    cfg.write_text('[pwa]\nurls = ["https://example.com/"]\n')
+
+    def fake_run(cmd, *args, **kwargs):
+        if list(cmd[:3]) == ["sudo", "-n", "true"]:
+            return sp.CompletedProcess(cmd, 1)  # not cached
+        if list(cmd[:2]) == ["sudo", "-v"]:
+            raise sp.CalledProcessError(1, cmd)
+        raise AssertionError(f"unexpected subprocess.run call: {cmd}")
+
+    monkeypatch.setattr(orch.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="auth failed"):
+        orch.cmd_apply(
+            _make_args(tmp_path, cfg),
+            display_name="Brave",
+            running_fn=lambda: False,
+            pids_fn=lambda: [],
+            find_cmdline_fn=lambda: None,
+            kill_fn=lambda: None,
+            restart_fn=lambda _cmd: [],
+            build_plans_fn=_build_pwa_only_plans,
+        )


### PR DESCRIPTION
Closes #13. Closes #14.

## Summary
Two parallel UX improvements that share `_base/orchestrator.py`:

- **#13 — TOML parse errors.** `_load_toml(path)` now wraps `tomllib.TOMLDecodeError` and `FileNotFoundError` and exits with a single-line error like `error: invalid TOML at <path>: ...`. Previously a malformed local TOML produced a raw traceback while the URL path next to it already failed cleanly.
- **#14 — sudo preflight on systems without sudo.** The cached `sudo -n true` check now lives inside the same `try/except` that already handled the interactive `sudo -v`. Containers / BSD / Termux without sudo previously hit `FileNotFoundError` before reaching the helpful auth-failed message.

## Test plan
- [x] `pytest tests/test_error_messages.py -v` — 5 new tests cover both code paths plus a happy-path round-trip.
- [x] Full suite: 170 passed (165 prior + 5 new).