### PR TITLE
feat: <browser> restore subcommand for rolling back an apply

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,10 +52,12 @@ items live in [issues](https://github.com/xom11/dotbrowser/issues).
 
 ## Feature ideas
 
-- **`<browser> restore [--from <backup>]`.** Backups already land at
-  `Preferences.bak.<timestamp>`. A `restore` subcommand picks the most
-  recent (or a named one) and copies it back. Saves users from `cp`
-  with the wrong path on macOS.
+- ~~**`<browser> restore [--from <backup>]`.**~~ ✅ Done — `restore`
+  picks the most recent backup (or `--from FILE`), copies it over
+  Preferences, and clears the shortcuts/settings sidecars. `--list`
+  enumerates available backups; `--dry-run` shows what would happen.
+  `[pwa]` policy file is intentionally out of scope (lives outside the
+  profile and isn't part of the per-apply backup).
 
 - **Dedicated `diff` subcommand.** Today the only preview is
   `apply --dry-run`, which reuses apply's output format. A real `diff`

--- a/src/dotbrowser/_base/orchestrator.py
+++ b/src/dotbrowser/_base/orchestrator.py
@@ -245,6 +245,116 @@ def cmd_apply(
         )
 
 
+_RESTORE_SIDECAR_NAMES = (
+    "Preferences.dotbrowser.shortcuts.json",
+    "Preferences.dotbrowser.settings.json",
+)
+
+
+def cmd_restore(
+    args: argparse.Namespace,
+    *,
+    display_name: str,
+    running_fn: Callable[[], bool],
+    pids_fn: Callable[[], list[str]],
+    find_cmdline_fn: Callable[[], list[str] | None],
+    kill_fn: Callable[[], None],
+    restart_fn: Callable[[list[str]], list[str]],
+) -> None:
+    """Restore Preferences from a backup created by a prior ``apply``.
+
+    Resolves a backup file (most recent by mtime, or the one passed via
+    ``--from``), copies it back over Preferences, and clears the
+    shortcuts/settings sidecars so the next apply starts from a clean
+    "managed by dotbrowser" set.
+
+    [pwa] is intentionally out of scope -- the policy file lives outside
+    the profile and isn't part of the per-apply backup.  The user is
+    told to edit the managed-policy file manually if they regret a pwa
+    write.
+    """
+    prefs_path = find_preferences(args.profile_root, args.profile)
+    profile_dir = prefs_path.parent
+    backups = sorted(
+        profile_dir.glob(f"{prefs_path.name}.bak.*"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+
+    if args.list:
+        if not backups:
+            print(f"no backups found next to {prefs_path}")
+            return
+        print(f"backups for {prefs_path}:")
+        for bk in backups:
+            ts = datetime.fromtimestamp(bk.stat().st_mtime).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            print(f"  {bk.name}  {ts}  ({bk.stat().st_size} bytes)")
+        return
+
+    if args.from_path:
+        backup = Path(args.from_path)
+        if not backup.exists():
+            sys.exit(f"error: backup not found: {backup}")
+    else:
+        if not backups:
+            sys.exit(
+                f"error: no backups found next to {prefs_path}.\n"
+                "(`apply` writes a timestamped backup on every run; "
+                "if you've never applied, there's nothing to restore.)"
+            )
+        backup = backups[0]
+
+    print(f"target:  {prefs_path}")
+    print(f"restore: {backup}")
+
+    if args.dry_run:
+        print("\n(dry-run, nothing written)")
+        return
+
+    saved_cmdline: list[str] | None = None
+    was_killed = False
+    if running_fn():
+        if not args.kill_browser:
+            sys.exit(
+                f"error: {display_name} is running. Close it first, "
+                f"or pass --kill-browser"
+            )
+        saved_cmdline = find_cmdline_fn()
+        pid_list = pids_fn()
+        print(f"killing {display_name} (pids: {' '.join(pid_list)})")
+        kill_fn()
+        was_killed = True
+
+    shutil.copy2(backup, prefs_path)
+    print(f"restored Preferences from {backup.name}")
+
+    # Clear sidecars so the next `apply` doesn't think the restored
+    # values are still under dotbrowser management -- they were the
+    # PRE-managed state when the backup was taken.
+    for sidecar in _RESTORE_SIDECAR_NAMES:
+        sp = profile_dir / sidecar
+        if sp.exists():
+            sp.unlink()
+            print(f"cleared {sidecar}")
+
+    print(
+        "note: [pwa] policy file is NOT affected by restore. If you "
+        "applied PWAs you no longer want, edit the managed-policy file "
+        "(see `<browser> pwa dump` for its location) manually."
+    )
+
+    if saved_cmdline:
+        used = restart_fn(saved_cmdline)
+        print(f"restarting {display_name}: {' '.join(used)}")
+    elif was_killed:
+        print(
+            f"{display_name} killed; could not capture original "
+            f"command line -- restart manually."
+        )
+
+
 def cmd_init(args: argparse.Namespace, browser_name: str, template: str) -> None:
     filename = args.output or f"{browser_name}.toml"
     text = template.replace("{filename}", filename)
@@ -266,6 +376,7 @@ def register_browser(
     default_profile_root: Path | None,
     cmd_apply_fn,
     cmd_init_fn=None,
+    cmd_restore_fn=None,
     module_registers: list,
     setup_profile_args: Callable[[argparse.ArgumentParser], None] | None = None,
     normalize_args: Callable[[argparse.Namespace], None] | None = None,
@@ -358,6 +469,32 @@ def register_browser(
         "prefs over our changes), apply, then restart it",
     )
     a.set_defaults(func=cmd_apply_fn)
+
+    if cmd_restore_fn is not None:
+        r = sub.add_parser(
+            "restore",
+            help="restore Preferences from a backup created by apply",
+        )
+        r.add_argument(
+            "--from",
+            dest="from_path",
+            metavar="FILE",
+            default=None,
+            help="path to a specific backup file (default: most recent)",
+        )
+        r.add_argument(
+            "--list",
+            action="store_true",
+            help="list available backups and exit",
+        )
+        r.add_argument("-n", "--dry-run", action="store_true")
+        r.add_argument(
+            "-k",
+            "--kill-browser",
+            action="store_true",
+            help=f"if {name} is running, force-kill it before restoring",
+        )
+        r.set_defaults(func=cmd_restore_fn)
 
     for mod_register in module_registers:
         mod_register(sub)

--- a/src/dotbrowser/brave/__init__.py
+++ b/src/dotbrowser/brave/__init__.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from dotbrowser._base.orchestrator import (
     cmd_apply as _base_cmd_apply,
     cmd_init as _base_cmd_init,
+    cmd_restore as _base_cmd_restore,
     register_browser,
 )
 from dotbrowser._base.utils import Plan
@@ -257,6 +258,39 @@ def cmd_init(args: argparse.Namespace) -> None:
     _base_cmd_init(args, "brave", _INIT_TEMPLATE)
 
 
+def cmd_restore(args: argparse.Namespace) -> None:
+    """Restore Preferences from an apply-time backup.
+
+    Resolves process callbacks the same way ``cmd_apply`` does so the
+    Linux non-stable channel filter (and macOS app-name distinction)
+    are honored when killing the right Brave install.
+    """
+    channel = getattr(args, "channel", "stable")
+    if channel == "stable":
+        _base_cmd_restore(
+            args,
+            display_name="Brave",
+            running_fn=brave_running,
+            pids_fn=_brave_pids,
+            find_cmdline_fn=find_main_brave_cmdline,
+            kill_fn=kill_brave_and_wait,
+            restart_fn=restart_brave,
+        )
+        return
+
+    from dotbrowser.brave.utils import _make_browser_process
+    proc = _make_browser_process(channel)
+    _base_cmd_restore(
+        args,
+        display_name=proc.display_name,
+        running_fn=proc.running,
+        pids_fn=proc.pids,
+        find_cmdline_fn=proc.find_main_cmdline,
+        kill_fn=proc.kill_and_wait,
+        restart_fn=proc.restart,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -269,6 +303,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default_profile_root=DEFAULT_PROFILE_ROOT,
         cmd_apply_fn=cmd_apply,
         cmd_init_fn=cmd_init,
+        cmd_restore_fn=cmd_restore,
         module_registers=[
             shortcuts_mod.register,
             settings_mod.register,

--- a/src/dotbrowser/edge/__init__.py
+++ b/src/dotbrowser/edge/__init__.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from dotbrowser._base.orchestrator import (
     cmd_apply as _base_cmd_apply,
     cmd_init as _base_cmd_init,
+    cmd_restore as _base_cmd_restore,
     register_browser,
 )
 from dotbrowser._base.utils import Plan
@@ -116,6 +117,18 @@ def cmd_init(args: argparse.Namespace) -> None:
     _base_cmd_init(args, "edge", _INIT_TEMPLATE)
 
 
+def cmd_restore(args: argparse.Namespace) -> None:
+    _base_cmd_restore(
+        args,
+        display_name="Edge",
+        running_fn=edge_running,
+        pids_fn=_edge_pids,
+        find_cmdline_fn=find_main_edge_cmdline,
+        kill_fn=kill_edge_and_wait,
+        restart_fn=restart_edge,
+    )
+
+
 def register(subparsers: argparse._SubParsersAction) -> None:
     register_browser(
         subparsers,
@@ -124,6 +137,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default_profile_root=DEFAULT_PROFILE_ROOT,
         cmd_apply_fn=cmd_apply,
         cmd_init_fn=cmd_init,
+        cmd_restore_fn=cmd_restore,
         module_registers=[
             settings_mod.register,
             pwa_mod.register,

--- a/src/dotbrowser/vivaldi/__init__.py
+++ b/src/dotbrowser/vivaldi/__init__.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from dotbrowser._base.orchestrator import (
     cmd_apply as _base_cmd_apply,
     cmd_init as _base_cmd_init,
+    cmd_restore as _base_cmd_restore,
     register_browser,
 )
 from dotbrowser._base.utils import Plan
@@ -132,6 +133,18 @@ def cmd_init(args: argparse.Namespace) -> None:
     _base_cmd_init(args, "vivaldi", _INIT_TEMPLATE)
 
 
+def cmd_restore(args: argparse.Namespace) -> None:
+    _base_cmd_restore(
+        args,
+        display_name="Vivaldi",
+        running_fn=vivaldi_running,
+        pids_fn=_vivaldi_pids,
+        find_cmdline_fn=find_main_vivaldi_cmdline,
+        kill_fn=kill_vivaldi_and_wait,
+        restart_fn=restart_vivaldi,
+    )
+
+
 def register(subparsers: argparse._SubParsersAction) -> None:
     register_browser(
         subparsers,
@@ -140,6 +153,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default_profile_root=DEFAULT_PROFILE_ROOT,
         cmd_apply_fn=cmd_apply,
         cmd_init_fn=cmd_init,
+        cmd_restore_fn=cmd_restore,
         module_registers=[
             shortcuts_mod.register,
             settings_mod.register,

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,0 +1,234 @@
+"""Tests for the `<browser> restore` subcommand.
+
+Driven via Brave (the same orchestrator code paths cover Edge / Vivaldi
+since `cmd_restore` lives in `_base/orchestrator.py`).  Each test
+synthesizes a profile + a backup file or two, calls `cmd_restore` in-
+process with a fake `Namespace`, and asserts the resulting filesystem
+state.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from dotbrowser import brave as brave_pkg
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _restore(
+    profile_root: Path,
+    *,
+    from_path: str | None = None,
+    list_only: bool = False,
+    dry_run: bool = False,
+    kill_browser: bool = False,
+) -> None:
+    args = argparse.Namespace(
+        profile_root=profile_root,
+        profile="Default",
+        from_path=from_path,
+        list=list_only,
+        dry_run=dry_run,
+        kill_browser=kill_browser,
+    )
+    brave_pkg.cmd_restore(args)
+
+
+def _run_cli(profile_root: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+    return subprocess.run(
+        [
+            sys.executable, "-m", "dotbrowser", "brave",
+            "--profile-root", str(profile_root), *extra,
+        ],
+        capture_output=True, text=True, env=env,
+    )
+
+
+@pytest.fixture
+def profile_with_backups(tmp_path: Path) -> tuple[Path, list[Path]]:
+    """Profile root with a current Preferences plus three timestamped
+    backups (oldest -> newest by mtime).  Includes both shortcuts and
+    settings sidecars so the clear-on-restore path can be exercised."""
+    profile = tmp_path / "Default"
+    profile.mkdir()
+
+    current = {"version": "current", "marker": "now"}
+    (profile / "Preferences").write_text(json.dumps(current))
+
+    # Sidecars that should get cleared on restore.
+    (profile / "Preferences.dotbrowser.shortcuts.json").write_text(
+        json.dumps({"managed_ids": ["35012"]})
+    )
+    (profile / "Preferences.dotbrowser.settings.json").write_text(
+        json.dumps({"managed_keys": ["brave.tabs.vertical_tabs_enabled"]})
+    )
+
+    backups: list[Path] = []
+    for i, marker in enumerate(("oldest", "middle", "newest")):
+        bak = profile / f"Preferences.bak.20260101-00000{i}"
+        bak.write_text(json.dumps({"version": marker, "marker": marker}))
+        # Force ascending mtimes so newest sorts last regardless of
+        # filesystem timestamp granularity.
+        os.utime(bak, (1_000_000 + i, 1_000_000 + i))
+        backups.append(bak)
+        # Tiny gap so test_list_orders_by_mtime sees distinct mtimes
+        # even on coarse-clock filesystems.
+        time.sleep(0.01)
+    return tmp_path, backups
+
+
+def test_restore_picks_most_recent_backup(
+    profile_with_backups: tuple[Path, list[Path]], monkeypatch
+) -> None:
+    monkeypatch.setattr(brave_pkg, "brave_running", lambda: False)
+    profile_root, backups = profile_with_backups
+    newest = backups[-1]
+
+    _restore(profile_root)
+
+    prefs = json.loads((profile_root / "Default" / "Preferences").read_text())
+    assert prefs["marker"] == "newest"
+    assert prefs == json.loads(newest.read_text())
+
+
+def test_restore_clears_sidecars(
+    profile_with_backups: tuple[Path, list[Path]], monkeypatch
+) -> None:
+    """Sidecars should be removed so the next apply doesn't try to
+    'remove' keys that the restore put back."""
+    monkeypatch.setattr(brave_pkg, "brave_running", lambda: False)
+    profile_root, _ = profile_with_backups
+
+    _restore(profile_root)
+
+    profile_dir = profile_root / "Default"
+    assert not (profile_dir / "Preferences.dotbrowser.shortcuts.json").exists()
+    assert not (profile_dir / "Preferences.dotbrowser.settings.json").exists()
+
+
+def test_restore_from_specific_backup(
+    profile_with_backups: tuple[Path, list[Path]], monkeypatch
+) -> None:
+    monkeypatch.setattr(brave_pkg, "brave_running", lambda: False)
+    profile_root, backups = profile_with_backups
+    middle = backups[1]
+
+    _restore(profile_root, from_path=str(middle))
+
+    prefs = json.loads((profile_root / "Default" / "Preferences").read_text())
+    assert prefs["marker"] == "middle"
+
+
+def test_restore_from_missing_backup_errors(
+    profile_with_backups: tuple[Path, list[Path]], tmp_path: Path
+) -> None:
+    profile_root, _ = profile_with_backups
+    bogus = tmp_path / "does-not-exist.bak"
+    with pytest.raises(SystemExit, match="backup not found"):
+        _restore(profile_root, from_path=str(bogus))
+
+
+def test_restore_no_backups_errors(tmp_path: Path) -> None:
+    profile = tmp_path / "Default"
+    profile.mkdir()
+    (profile / "Preferences").write_text("{}")
+    with pytest.raises(SystemExit, match="no backups found"):
+        _restore(tmp_path)
+
+
+def test_restore_dry_run_does_not_write(
+    profile_with_backups: tuple[Path, list[Path]], monkeypatch
+) -> None:
+    monkeypatch.setattr(brave_pkg, "brave_running", lambda: False)
+    profile_root, _ = profile_with_backups
+
+    prefs_path = profile_root / "Default" / "Preferences"
+    before = prefs_path.read_bytes()
+    sidecar_before = (
+        profile_root / "Default" / "Preferences.dotbrowser.shortcuts.json"
+    ).read_bytes()
+
+    _restore(profile_root, dry_run=True)
+
+    assert prefs_path.read_bytes() == before
+    assert (
+        profile_root / "Default" / "Preferences.dotbrowser.shortcuts.json"
+    ).read_bytes() == sidecar_before
+
+
+def test_restore_refuses_when_running_without_kill(
+    profile_with_backups: tuple[Path, list[Path]], monkeypatch
+) -> None:
+    monkeypatch.setattr(brave_pkg, "brave_running", lambda: True)
+    profile_root, _ = profile_with_backups
+    with pytest.raises(SystemExit, match="--kill-browser"):
+        _restore(profile_root)
+
+
+def test_list_lists_backups_newest_first(
+    profile_with_backups: tuple[Path, list[Path]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    profile_root, _ = profile_with_backups
+    _restore(profile_root, list_only=True)
+    out = capsys.readouterr().out
+    # All three backup filenames are present
+    assert "Preferences.bak.20260101-000000" in out
+    assert "Preferences.bak.20260101-000001" in out
+    assert "Preferences.bak.20260101-000002" in out
+    # newest (index 2) appears before oldest (index 0)
+    assert out.index("000002") < out.index("000000")
+
+
+def test_list_with_no_backups_does_not_crash(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    profile = tmp_path / "Default"
+    profile.mkdir()
+    (profile / "Preferences").write_text("{}")
+    _restore(tmp_path, list_only=True)
+    assert "no backups found" in capsys.readouterr().out
+
+
+def test_cli_restore_help_lists_flags() -> None:
+    """Smoke test the argparse wiring -- restore must appear in `--help`
+    with --from / --list / --dry-run / --kill-browser."""
+    profile = REPO_ROOT  # arbitrary path; --help short-circuits
+    r = _run_cli(profile, "restore", "--help")
+    assert r.returncode == 0
+    out = r.stdout
+    for flag in ("--from", "--list", "--dry-run", "--kill-browser"):
+        assert flag in out
+
+
+def test_cli_edge_has_restore() -> None:
+    """Edge wires the same restore subcommand."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+    r = subprocess.run(
+        [sys.executable, "-m", "dotbrowser", "edge", "--help"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 0
+    assert "restore" in r.stdout
+
+
+def test_cli_vivaldi_has_restore() -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+    r = subprocess.run(
+        [sys.executable, "-m", "dotbrowser", "vivaldi", "--help"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 0
+    assert "restore" in r.stdout


### PR DESCRIPTION
Implements the ROADMAP "browser restore [--from <backup>]" entry.

## Summary
`dotbrowser <browser> restore` rolls Preferences back to a backup created by a prior `apply`:
- default: most recent `Preferences.bak.*` by mtime
- `--from FILE`: a specific backup
- `--list`: enumerate backups (newest first) and exit
- `--dry-run`, `--kill-browser`: same semantics as apply

The shortcuts/settings sidecars are cleared after the copy so the next `apply` starts from a clean managed-key set instead of trying to "remove" keys the restore put back.

`[pwa]` is intentionally out of scope — the managed-policy file lives outside the profile and isn't part of the per-apply backup. Restore prints a note pointing users at the policy file if they need to revert pwa changes.

Brave's wrapper resolves process callbacks per channel (mirrors `cmd_apply`) so `dotbrowser brave --channel beta restore --kill-browser` only kills beta.

## Test plan
- [x] `pytest tests/test_restore.py -v` — 12 new tests pass.
- [x] Full suite: 189 passed (177 prior + 12 new).
- [x] CLI smoke: `restore` appears in `--help` for brave / edge / vivaldi.