### PR TITLE
fix: init template repo URL + require https for [pwa] urls

### DIFF
--- a/src/dotbrowser/_base/pwa.py
+++ b/src/dotbrowser/_base/pwa.py
@@ -91,8 +91,8 @@ def validate_table(raw: object) -> list[str]:
     for u in urls:
         if not isinstance(u, str):
             sys.exit(f"error: [pwa] url entries must be strings, got {type(u).__name__}")
-        if not u.startswith(("http://", "https://")):
-            sys.exit(f"error: [pwa] invalid url {u!r} (must start with http:// or https://)")
+        if not u.startswith("https://"):
+            sys.exit(f"error: [pwa] invalid url {u!r} (must start with https://)")
         if u in seen:
             continue
         seen.add(u)

--- a/src/dotbrowser/brave/__init__.py
+++ b/src/dotbrowser/brave/__init__.py
@@ -122,7 +122,7 @@ def _build_plans(prefs_path: Path, prefs: dict, doc: dict) -> list[Plan]:
 
 _INIT_TEMPLATE = """\
 # dotbrowser -- Brave configuration
-# Docs: https://github.com/nichochar/dotbrowser
+# Docs: https://github.com/xom11/dotbrowser
 # List available shortcut names:  dotbrowser brave shortcuts list
 # Inspect current settings:       dotbrowser brave settings dump
 #

--- a/src/dotbrowser/edge/__init__.py
+++ b/src/dotbrowser/edge/__init__.py
@@ -68,7 +68,7 @@ def _build_plans(prefs_path: Path, prefs: dict, doc: dict) -> list[Plan]:
 
 _INIT_TEMPLATE = """\
 # dotbrowser -- Microsoft Edge configuration
-# Docs: https://github.com/nichochar/dotbrowser
+# Docs: https://github.com/xom11/dotbrowser
 # Inspect current settings:  dotbrowser edge settings dump
 #
 # Apply this file:

--- a/src/dotbrowser/vivaldi/__init__.py
+++ b/src/dotbrowser/vivaldi/__init__.py
@@ -78,7 +78,7 @@ def _build_plans(prefs_path: Path, prefs: dict, doc: dict) -> list[Plan]:
 
 _INIT_TEMPLATE = """\
 # dotbrowser -- Vivaldi configuration
-# Docs: https://github.com/nichochar/dotbrowser
+# Docs: https://github.com/xom11/dotbrowser
 # List available shortcut names:  dotbrowser vivaldi shortcuts list
 # Inspect current settings:       dotbrowser vivaldi settings dump
 #

--- a/tests/test_pwa_apply.py
+++ b/tests/test_pwa_apply.py
@@ -179,11 +179,13 @@ def test_validate_rejects_non_string_url_entries() -> None:
         pwa._validate_table({"urls": [123]})
 
 
-def test_validate_rejects_non_http_urls() -> None:
-    with pytest.raises(SystemExit, match=r"must start with http"):
+def test_validate_rejects_non_https_urls() -> None:
+    with pytest.raises(SystemExit, match=r"must start with https://"):
         pwa._validate_table({"urls": ["javascript:alert(1)"]})
-    with pytest.raises(SystemExit, match=r"must start with http"):
+    with pytest.raises(SystemExit, match=r"must start with https://"):
         pwa._validate_table({"urls": ["squoosh.app"]})  # missing scheme
+    with pytest.raises(SystemExit, match=r"must start with https://"):
+        pwa._validate_table({"urls": ["http://example.com/"]})  # plain http
 
 
 def test_validate_rejects_unknown_keys() -> None:

--- a/tests/test_vivaldi_logic.py
+++ b/tests/test_vivaldi_logic.py
@@ -203,6 +203,8 @@ def test_pwa_validate_accepts_url_list() -> None:
     assert out == ["https://squoosh.app/"]
 
 
-def test_pwa_validate_rejects_non_http() -> None:
-    with pytest.raises(SystemExit, match="must start with http"):
+def test_pwa_validate_rejects_non_https() -> None:
+    with pytest.raises(SystemExit, match="must start with https://"):
         pwa._validate_table({"urls": ["javascript:alert(1)"]})
+    with pytest.raises(SystemExit, match="must start with https://"):
+        pwa._validate_table({"urls": ["http://example.com/"]})


### PR DESCRIPTION
## Summary

- Init templates referenced `github.com/nichochar/dotbrowser`; the real repo is `xom11/dotbrowser`. Fixed in `brave`, `vivaldi`, and `edge` init templates.
- `[pwa]` URL validator accepted both `http://` and `https://`. Force-installed PWAs over plain http have no encryption and a MITM can rewrite the manifest before Brave/Edge fetch it, so tighten to `https://` only. Error message and tests updated.

## Test plan

- [x] `pytest` — 186 passed, 3 skipped
- [x] `dotbrowser brave init | head -3` shows `xom11/dotbrowser`
- [x] `dotbrowser vivaldi init | head -3` shows `xom11/dotbrowser`
- [x] `dotbrowser edge init | head -3` shows `xom11/dotbrowser`
- [x] `[pwa] urls = ["http://example.com/"]` now refused with `must start with https://` and exit 1