### PR TITLE
build: add Nix flake for nix run / nix profile install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ venv/
 htmlcov/
 .coverage
 *.bak.*
+
+# nix
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Manage browser settings as dotfiles (Brave, Vivaldi, Edge)";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (system:
+        let pkgs = pkgsFor system; in {
+          dotbrowser = pkgs.python3Packages.buildPythonApplication {
+            pname = "dotbrowser";
+            version = builtins.head
+              (builtins.match ''.*__version__ = "([^"]+)".*''
+                (builtins.readFile ./src/dotbrowser/__init__.py));
+            pyproject = true;
+            src = ./.;
+            build-system = [ pkgs.python3Packages.hatchling ];
+            nativeCheckInputs = [ pkgs.python3Packages.pytestCheckHook ];
+            disabledTests = [
+              # touches the real on-disk Brave profile, skipped via env in CI too
+              "test_dump_real_profile_succeeds"
+              "test_dry_run_apply_real_profile_does_not_write"
+            ];
+            meta = with pkgs.lib; {
+              description = "Manage browser settings as dotfiles (Brave, Vivaldi, Edge)";
+              homepage = "https://github.com/xom11/dotbrowser";
+              license = licenses.mit;
+              mainProgram = "dotbrowser";
+              platforms = platforms.unix ++ platforms.windows;
+            };
+          };
+          default = self.packages.${system}.dotbrowser;
+        });
+
+      devShells = forAllSystems (system:
+        let pkgs = pkgsFor system; in {
+          default = pkgs.mkShell {
+            packages = [
+              (pkgs.python3.withPackages (ps: [ ps.pytest ]))
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Summary

- Adds `flake.nix` exposing a `dotbrowser` package + a default `devShell`
- Version is read from `src/dotbrowser/__init__.py` so the flake stays in lock-step with PyPI releases
- Builds + runs the test suite (184 passed) in the Nix sandbox; two smoke tests that touch the user's real Brave profile are disabled there
- Adds `result` / `result-*` to `.gitignore` (Nix build symlinks)

After merge, users can install without a clone:

```sh
nix run github:xom11/dotbrowser -- brave init
nix profile install github:xom11/dotbrowser
```

Supports `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`.

## Test plan

- [x] `nix flake check --no-build` — clean
- [x] `nix build .#` — built `dotbrowser-0.4.0` against nixpkgs unstable on aarch64-linux
- [x] `nix run .# -- --version` prints `dotbrowser 0.4.0`
- [x] In-build pytest: 184 passed, 3 skipped (macOS-only), 2 deselected (live-profile smoke tests)