### PR TITLE
fix(vivaldi): actionable error when actions[0] is unseeded

### DIFF
--- a/src/dotbrowser/vivaldi/shortcuts.py
+++ b/src/dotbrowser/vivaldi/shortcuts.py
@@ -50,6 +50,20 @@ from dotbrowser.vivaldi.utils import (
 ACTIONS_KEY_PATH = ("vivaldi", "actions")
 NAMESPACE = "shortcuts"
 
+# Shown when `vivaldi.actions[0]` is empty / missing. Vivaldi only writes
+# the compiled-in command catalog into Preferences after the user touches
+# Settings -> Keyboard and the browser flushes on a clean quit. Without
+# this hint, the user sees "unknown command" for every standard COMMAND_*
+# (or "0 commands" from `shortcuts list`) with no path to the fix.
+_UNINITIALIZED_HINT = (
+    "this Vivaldi profile has not seeded its keyboard command catalog yet "
+    "(`vivaldi.actions[0]` in Preferences is empty or missing). Vivaldi "
+    "writes the catalog only after Settings -> Keyboard has been touched "
+    "and the browser has been fully quit (not just window-closed). "
+    "Open Vivaldi, change or reset any shortcut under Settings -> Keyboard, "
+    "quit the browser entirely so it flushes Preferences, then re-run."
+)
+
 
 def _validate_table(raw: object) -> dict[str, list[str]]:
     if not isinstance(raw, dict):
@@ -142,6 +156,13 @@ def plan_apply(prefs_path: Path, prefs: dict, raw_table: object) -> Plan:
     """
     config = _validate_table(raw_table)
     current = _get_actions_dict(prefs)
+
+    # Distinguish "uninitialized profile" from "user typo" before the
+    # generic unknown-command check: against an empty catalog every name
+    # would be reported unknown, and the typo-flavored hint pointing to
+    # `shortcuts list` is a dead end (it would also print 0 commands).
+    if config and not current:
+        sys.exit("error: " + _UNINITIALIZED_HINT)
 
     unknown = sorted(name for name in config if name not in current)
     if unknown:
@@ -282,6 +303,11 @@ def cmd_list(args: argparse.Namespace) -> None:
     for name in rows:
         print(name)
     print(f"\n{len(rows)} commands", file=sys.stderr)
+    # Empty catalog is almost always an uninitialized profile, not a
+    # too-narrow filter. Surface the same hint `apply` uses so users
+    # who run `list` to diagnose land on the answer.
+    if not actions:
+        print(_UNINITIALIZED_HINT, file=sys.stderr)
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:

--- a/tests/test_vivaldi_apply.py
+++ b/tests/test_vivaldi_apply.py
@@ -143,6 +143,48 @@ def test_apply_unknown_command_errors(
     assert before == after
 
 
+def _make_uninitialized_profile_root(tmp_path: Path) -> Path:
+    """Profile root mirroring a freshly-installed Vivaldi: no
+    `vivaldi.actions` key in Preferences. Reproduces the failure mode
+    seen on Linux profiles that have never visited Settings -> Keyboard.
+    """
+    profile = tmp_path / "Default"
+    profile.mkdir()
+    (profile / "Preferences").write_text(json.dumps({"vivaldi": {}}))
+    return tmp_path
+
+
+def test_apply_uninitialized_profile_emits_seeding_hint(tmp_path: Path) -> None:
+    """The seeding hint must reach the user via the CLI (not just the
+    pure-logic path) and Preferences must remain untouched.
+    """
+    profile_root = _make_uninitialized_profile_root(tmp_path)
+    cfg = tmp_path / "v.toml"
+    cfg.write_text('[shortcuts]\nCOMMAND_CLOSE_TAB = ["meta+w"]\n')
+
+    before = (profile_root / "Default" / "Preferences").read_bytes()
+    r = _run_cli(profile_root, "apply", str(cfg))
+    assert r.returncode != 0
+    combined = r.stdout + r.stderr
+    assert "has not seeded" in combined
+    # The misleading typo-flavored hint must NOT be the one shown here.
+    assert "unknown Vivaldi command" not in combined
+    after = (profile_root / "Default" / "Preferences").read_bytes()
+    assert before == after
+
+
+def test_list_on_uninitialized_profile_shows_hint(tmp_path: Path) -> None:
+    """`shortcuts list` against an unseeded profile prints `0 commands`
+    plus the seeding hint, so users running it to diagnose the apply
+    failure get the same actionable advice.
+    """
+    profile_root = _make_uninitialized_profile_root(tmp_path)
+    r = _run_cli(profile_root, "shortcuts", "list")
+    assert r.returncode == 0
+    assert "0 commands" in r.stderr
+    assert "has not seeded" in r.stderr
+
+
 def test_dump_against_fake_profile(fake_vivaldi_profile_root: Path) -> None:
     """`shortcuts dump` (default) emits commands with non-empty bindings."""
     r = _run_cli(fake_vivaldi_profile_root, "shortcuts", "dump")

--- a/tests/test_vivaldi_logic.py
+++ b/tests/test_vivaldi_logic.py
@@ -167,6 +167,41 @@ def test_plan_apply_rejects_unknown_command(tmp_path: Path) -> None:
         sc.plan_apply(prefs_path, prefs, {"COMMAND_NOT_REAL": ["x"]})
 
 
+def test_plan_apply_uninitialized_profile_distinct_error(tmp_path: Path) -> None:
+    """A fresh Vivaldi profile that hasn't visited Settings -> Keyboard
+    has an empty (or missing) `vivaldi.actions[0]`. Against that, every
+    standard COMMAND_* would otherwise be reported as unknown — pointing
+    the user toward `shortcuts list`, which is also empty. Detect this
+    case explicitly and emit the seeding hint instead.
+    """
+    prefs_path = tmp_path / "Preferences"
+    prefs = _make_prefs({})  # actions[0] = {}, the uninitialized shape
+    with pytest.raises(SystemExit, match="has not seeded"):
+        sc.plan_apply(prefs_path, prefs, {"COMMAND_CLOSE_TAB": ["meta+w"]})
+
+
+def test_plan_apply_missing_actions_key_distinct_error(tmp_path: Path) -> None:
+    """Same as above but the `vivaldi.actions` key is absent entirely
+    (observed on freshly-installed Linux profiles). The seeding hint
+    must fire here too — not the unknown-command branch.
+    """
+    prefs_path = tmp_path / "Preferences"
+    prefs: dict = {"vivaldi": {}}
+    with pytest.raises(SystemExit, match="has not seeded"):
+        sc.plan_apply(prefs_path, prefs, {"COMMAND_CLOSE_TAB": ["meta+w"]})
+
+
+def test_plan_apply_empty_table_on_uninitialized_profile_is_noop(tmp_path: Path) -> None:
+    """If both the profile *and* the user's `[shortcuts]` table are
+    empty, there's nothing to apply — the seeding hint should NOT fire
+    because we have no commands to validate.
+    """
+    prefs_path = tmp_path / "Preferences"
+    prefs = _make_prefs({})
+    plan = sc.plan_apply(prefs_path, prefs, {})
+    assert plan.diff_lines == []
+
+
 def test_plan_apply_diff_lines_shapes(tmp_path: Path) -> None:
     """Verify the diff line prefixes for the three transitions:
     + new (no current entry), ~ change, - restore."""


### PR DESCRIPTION
Closes #28.

## Summary

- Detect "uninitialized profile" (empty / missing `vivaldi.actions[0]`) in `plan_apply` and emit a dedicated error explaining the seeding workflow, instead of falling through to the generic "unknown Vivaldi command(s)" branch which sent users to `shortcuts list` (also empty).
- Mirror the same hint in `cmd_list` so a user running `shortcuts list` to diagnose the apply failure lands on the answer too.

## Why this matters

On a freshly-installed Vivaldi profile that has never visited Settings -> Keyboard, `Preferences` doesn't contain `vivaldi.actions` at all (observed on Linux x86_64; reproducible with `python3 -c "import json,sys; print('actions' in json.load(open(sys.argv[1])).get('vivaldi',{}))" ~/.config/vivaldi/Default/Preferences`). Against that empty catalog every COMMAND_* in the user's TOML hit the unknown-command branch:

```
error: unknown Vivaldi command(s): COMMAND_ADD_BOOKMARK, COMMAND_CLOSE_TAB, ...
run `dotbrowser vivaldi shortcuts list` to see known commands
```

…but `shortcuts list` returned `0 commands`, leaving no path to the real fix.

After this change, the user gets:

```
error: this Vivaldi profile has not seeded its keyboard command catalog yet
(`vivaldi.actions[0]` in Preferences is empty or missing). Vivaldi writes the
catalog only after Settings -> Keyboard has been touched and the browser has
been fully quit (not just window-closed). Open Vivaldi, change or reset any
shortcut under Settings -> Keyboard, quit the browser entirely so it flushes
Preferences, then re-run.
```

## Test plan

- [x] `pytest tests/test_vivaldi_logic.py tests/test_vivaldi_apply.py` — added unit tests for both `plan_apply` paths (empty `actions[0]` and missing `actions` key entirely) plus an empty-table no-op regression test, and CLI integration tests for `apply` and `shortcuts list` against an unseeded profile.
- [x] Full `pytest` — 216 passed, 4 skipped (platform-specific), no regressions.
- [x] Manual repro on the original Linux profile that triggered #28: error now points to the correct fix; after the workaround the same TOML applies cleanly.