### PR TITLE
feat(vivaldi): schema-aware [settings] coercion + search/describe subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,12 @@ dotbrowser edge apply examples/edge/all.toml
 dotbrowser chrome init
 dotbrowser chrome apply examples/chrome/all.toml
 
+# Vivaldi-only: query the prefs schema (uses Vivaldi's bundled
+# prefs_definitions.json; falls back gracefully if it can't be found,
+# overridable via DOTBROWSER_VIVALDI_PREFS_DEF)
+dotbrowser vivaldi settings search "tab bar position"
+dotbrowser vivaldi settings describe vivaldi.tabs.bar.position
+
 # Regenerate command_ids.py from upstream Chromium + brave-core headers
 # (requires `gh` CLI authenticated)
 python scripts/generate_brave_command_ids.py
@@ -66,6 +72,7 @@ Tests live under `tests/` and use `pytest` (install via `pip install -e ".[test]
 - `test_edge_apply.py` — Edge settings apply, MAC refusal, dry-run, empty-config error, and `init` command. Same pattern as the Brave apply tests but for Edge (settings + pwa only, no shortcuts).
 - `test_chrome_apply.py` — Chrome settings apply, MAC refusal (covers both `Preferences.protection.macs` and `Secure Preferences.protection.macs`), dry-run, empty-config error, `init`, and the full pwa lifecycle. Mirrors `test_edge_apply.py`.
 - `test_export.py` — `<browser> export` for all four browsers. Redirects each browser's `pwa.POLICY_FILE` and `_read_existing_payload` to a tmp JSON file (same pattern as `test_pwa_apply.py`) so reads are deterministic without touching `/etc/`, `/Library/`, or the registry. Verifies (a) Brave's `[shortcuts]` is a diff against `brave.default_accelerators` and `--all-shortcuts` lifts that filter, (b) `[pwa]` reflects the seeded policy file, (c) Edge/Chrome omit `[shortcuts]` entirely, (d) Vivaldi emits every command with non-empty bindings (no defaults mirror to diff against), (e) the exported TOML is parseable and round-trips through `plan_apply` as a no-op.
+- `test_vivaldi_schema.py` — Vivaldi-only prefs-schema layer. Schema discovery via `DOTBROWSER_VIVALDI_PREFS_DEF`, flattening of both shapes (`vivaldi.*` nested tree and `chromium`/`chromium_local` `{kIdent: {path, type}}` tables), enum-name → int coercion, type-mismatch errors, unknown-key warning suppression for keys already present in `Preferences`, the `plan_apply` integration (warnings flow through `Plan.warnings`), and the `settings search` / `settings describe` CLI commands.
 
 The `--kill-browser` path is intentionally NOT covered by pytest (it would interrupt the user's running browser). Verify it manually after code changes.
 
@@ -128,7 +135,7 @@ brave/utils         -> BROWSER_PROCESS config + backward-compat aliases
 brave/command_ids   -> auto-generated IDC_* -> numeric ID mapping.
 ```
 
-Vivaldi follows the same pattern. Edge and Chrome are simpler (no shortcuts module — neither browser exposes a customizable accelerator API in `Preferences`).
+Vivaldi follows the same pattern, with one extra: `vivaldi/schema.py` reads the `prefs_definitions.json` Vivaldi ships at `<install>/resources/vivaldi/prefs_definitions.json` (Brave/Edge/Chrome don't ship a comparable file). Used for two things: (1) `vivaldi/settings.plan_apply` runs `coerce_and_validate` against the schema before delegating to `_base.settings.plan_apply`, so enum-name strings (`"left"`) are coerced to the int Vivaldi actually stores (`1`) and obvious type mismatches abort the apply with a clear error rather than silently no-op at runtime; (2) `settings search` and `settings describe` subcommands provide discoverability without grepping the 25k-line schema by hand. The loader is graceful when the schema can't be located -- `apply` falls back to the pre-schema behavior (write blindly) and the new subcommands print "schema not found". Override path with `DOTBROWSER_VIVALDI_PREFS_DEF`. The unknown-key warning suppresses for keys already present in `Preferences` because Vivaldi has many runtime-set prefs (e.g. `vivaldi.tabs.vertical_tabs_enabled`) that aren't declared in the schema -- naive warning would fire on every legitimate write. Edge and Chrome are simpler (no shortcuts module — neither browser exposes a customizable accelerator API in `Preferences`).
 
 **The `Plan` dataclass is the contract between modules and the orchestrator.** Each module's `plan_apply()` is pure -- validates the TOML table, reads existing state, computes the diff, and returns a `Plan` with `namespace`, `diff_lines`, `apply_fn(prefs)`, `verify_fn(reloaded)`, plus optional `state_path`/`state_payload` (for sidecar persistence) and optional `external_apply_fn` (for side effects outside `Preferences`, like pwa's policy file write). The orchestrator collects plans, prints the combined diff, runs a sudo preflight if any plan has an `external_apply_fn`, then in order: kills the browser (if needed), backs up Preferences, runs all `apply_fn`s against one in-memory dict, runs all `external_apply_fn`s (privileged side-effects like the pwa policy write), `write_atomic` (commits Preferences), writes state sidecars, runs `verify_fn`s. External writes run *before* `write_atomic` so a sudo/I/O failure leaves Preferences untouched -- the alternative ordering committed prefs first and could strand the user with shortcuts/settings applied but pwa silently un-applied. This guarantees: one backup per apply, no partial writes if any module rejects, sudo prompts come *before* the kill so an auth failure doesn't strand the user with a dead browser, and a single kill-browser + restart cycle.
 

--- a/src/dotbrowser/_base/settings.py
+++ b/src/dotbrowser/_base/settings.py
@@ -363,7 +363,17 @@ def cmd_dump(browser_name: str, args: argparse.Namespace) -> None:
         sys.stdout.write(out)
 
 
-def register(browser_name: str, subparsers: argparse._SubParsersAction) -> None:
+def register(
+    browser_name: str, subparsers: argparse._SubParsersAction
+) -> argparse._SubParsersAction:
+    """Register the ``settings`` subcommand and return its action sub-parser.
+
+    The returned object is the inner ``add_subparsers()`` action; per-
+    browser modules append extra actions (e.g. Vivaldi adds ``search``
+    and ``describe`` once the prefs schema is loaded) by calling
+    ``add_parser()`` on it.  Browsers that don't extend ignore the
+    return value -- behavior is unchanged.
+    """
     p = subparsers.add_parser(
         "settings",
         help=f"inspect general settings (apply lives at `{browser_name} apply`)",
@@ -388,3 +398,5 @@ def register(browser_name: str, subparsers: argparse._SubParsersAction) -> None:
     )
     b.add_argument("-o", "--output", help="write to file instead of stdout")
     b.set_defaults(func=lambda args, bn=browser_name: cmd_blocked(bn, args))
+
+    return sub

--- a/src/dotbrowser/vivaldi/schema.py
+++ b/src/dotbrowser/vivaldi/schema.py
@@ -1,0 +1,361 @@
+"""Vivaldi prefs-schema awareness.
+
+Vivaldi ships a complete prefs schema at
+``<install>/resources/vivaldi/prefs_definitions.json`` describing every
+key it stores in ``Preferences`` -- type, default, and (for enums) the
+``name -> int`` mapping.  Brave/Edge/Chrome ship no comparable file, so
+this module is intentionally Vivaldi-only.
+
+What this is for:
+
+1. ``apply`` time -- coerce friendly TOML values (e.g. enum names like
+   ``"left"``) into the on-disk integer Vivaldi expects, and reject
+   obvious type mismatches before they silently no-op at runtime.
+
+2. ``settings search`` / ``settings describe`` -- discoverability:
+   "what's the key for tab bar position?" without grepping a 25k-line
+   JSON manually.
+
+The loader is cached and falls back to ``None`` when the schema can't
+be located -- in that case ``apply`` keeps its pre-schema behavior
+(write blindly, hope for the best) and the new subcommands print a
+clear "schema not found" message instead of crashing.
+"""
+from __future__ import annotations
+
+import functools
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+# Top-level keys in prefs_definitions.json that hold pref defs.  Other
+# top-level keys (``syncable``, ``important``, ``documentation``) are
+# metadata and skipped.
+_VIVALDI_ROOTS: tuple[str, ...] = ("vivaldi",)
+_CHROMIUM_ROOTS: tuple[str, ...] = ("chromium", "chromium_local")
+
+# Field that marks a node as a pref leaf (vs. an intermediate group).
+_TYPE_FIELD = "type"
+
+# Env var override -- mainly for tests, but also useful when Vivaldi is
+# installed somewhere unusual.
+_ENV_OVERRIDE = "DOTBROWSER_VIVALDI_PREFS_DEF"
+
+
+def _candidate_paths() -> list[Path]:
+    """Filesystem locations where Vivaldi may have installed the schema.
+
+    Order matters: stable channel first, then snapshots, then user-local
+    flatpak-style installs.  The first one that exists wins.
+    """
+    home = Path.home()
+    if sys.platform == "darwin":
+        return [
+            Path("/Applications/Vivaldi.app/Contents/Resources/vivaldi/prefs_definitions.json"),
+            home / "Applications/Vivaldi.app/Contents/Resources/vivaldi/prefs_definitions.json",
+        ]
+    if sys.platform.startswith("linux"):
+        return [
+            Path("/opt/vivaldi/resources/vivaldi/prefs_definitions.json"),
+            Path("/opt/vivaldi-snapshot/resources/vivaldi/prefs_definitions.json"),
+            Path("/usr/lib/vivaldi/resources/vivaldi/prefs_definitions.json"),
+            Path("/usr/share/vivaldi/resources/vivaldi/prefs_definitions.json"),
+            home / ".local/share/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/vivaldi/resources/vivaldi/prefs_definitions.json",
+            Path("/var/lib/flatpak/app/com.vivaldi.Vivaldi/current/active/files/extra/vivaldi/resources/vivaldi/prefs_definitions.json"),
+        ]
+    if sys.platform == "win32":
+        candidates: list[Path] = []
+        for env in ("LOCALAPPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)"):
+            base = os.environ.get(env)
+            if not base:
+                continue
+            root = Path(base) / "Vivaldi" / "Application"
+            if not root.exists():
+                continue
+            for child in root.iterdir():
+                if child.is_dir() and child.name[:1].isdigit():
+                    candidate = child / "resources" / "vivaldi" / "prefs_definitions.json"
+                    if candidate.exists():
+                        candidates.append(candidate)
+        return candidates
+    return []
+
+
+def find_schema_path() -> Path | None:
+    """First existing schema path, or ``None``.
+
+    Honors ``DOTBROWSER_VIVALDI_PREFS_DEF`` for explicit override -- the
+    env var wins even if it points at a missing file (so tests can
+    assert "schema absent" deterministically).
+    """
+    override = os.environ.get(_ENV_OVERRIDE)
+    if override is not None:
+        p = Path(override)
+        return p if p.exists() else None
+    for cand in _candidate_paths():
+        if cand.exists():
+            return cand
+    return None
+
+
+def _is_leaf(node: Any) -> bool:
+    return isinstance(node, dict) and _TYPE_FIELD in node
+
+
+def _flatten_vivaldi_subtree(node: Any, prefix: tuple[str, ...]) -> Iterator[tuple[str, dict]]:
+    """Walk the ``vivaldi`` subtree, emitting ``(dotted_key, def)``.
+
+    Vivaldi prefs are expressed as nested objects: a leaf is any dict
+    that carries a ``type`` field.  Intermediate groups recurse.
+    """
+    if _is_leaf(node):
+        yield ".".join(prefix), node
+        return
+    if not isinstance(node, dict):
+        return
+    for k, v in node.items():
+        yield from _flatten_vivaldi_subtree(v, prefix + (k,))
+
+
+def _flatten_chromium_subtree(node: Any) -> Iterator[tuple[str, dict]]:
+    """Walk a chromium-style subtree, emitting ``(dotted_key, def)``.
+
+    Chromium prefs are expressed as a flat dict ``{kFooBar: {path:
+    "foo.bar", type: ...}}`` -- the actual dotted key lives in the
+    ``path`` field, and the C++ identifier (``kFooBar``) is just a
+    handle.  Entries without a ``path`` are skipped.
+    """
+    if not isinstance(node, dict):
+        return
+    for entry in node.values():
+        if not isinstance(entry, dict):
+            continue
+        path = entry.get("path")
+        if isinstance(path, str) and path and _TYPE_FIELD in entry:
+            yield path, entry
+
+
+@functools.lru_cache(maxsize=1)
+def load_schema() -> dict[str, dict] | None:
+    """Return ``{dotted_key: def}`` or ``None`` when no schema is found.
+
+    Cached for the process lifetime; schema doesn't change while
+    dotbrowser is running.  Tests that need to flip the schema across
+    cases call ``load_schema.cache_clear()``.
+    """
+    path = find_schema_path()
+    if path is None:
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    flat: dict[str, dict] = {}
+    for root in _VIVALDI_ROOTS:
+        sub = raw.get(root)
+        if isinstance(sub, dict):
+            for key, defn in _flatten_vivaldi_subtree(sub, (root,)):
+                flat[key] = defn
+    for root in _CHROMIUM_ROOTS:
+        sub = raw.get(root)
+        if isinstance(sub, dict):
+            for key, defn in _flatten_chromium_subtree(sub):
+                flat[key] = defn
+    return flat
+
+
+def lookup(schema: dict[str, dict] | None, key: str) -> dict | None:
+    """Return the def for ``key`` or ``None``."""
+    if schema is None:
+        return None
+    return schema.get(key)
+
+
+# --------------------------------------------------------------------------
+# Coercion + validation
+# --------------------------------------------------------------------------
+
+# Map schema ``type`` -> Python type(s) the value must be (post-coercion).
+# ``enum`` is handled separately because it gets coerced.  ``double`` is
+# float|int (TOML emits ints for whole numbers, JSON keeps the float).
+# ``file_path`` is just a string at the JSON layer.
+_TYPE_CHECK: dict[str, tuple[type, ...]] = {
+    "boolean": (bool,),
+    "integer": (int,),
+    "double": (int, float),
+    "string": (str,),
+    "file_path": (str,),
+    "list": (list,),
+    "dictionary": (dict,),
+}
+
+
+def _is_strict_int(v: Any) -> bool:
+    return isinstance(v, int) and not isinstance(v, bool)
+
+
+def _check_simple(t: Any, v: Any) -> bool:
+    """Whether ``v`` matches schema type ``t`` (non-enum types only)."""
+    if not isinstance(t, str):
+        return True
+    expected = _TYPE_CHECK.get(t)
+    if expected is None:
+        # Unknown type -- be permissive rather than reject.
+        return True
+    if t == "boolean":
+        return isinstance(v, bool)
+    if t == "integer":
+        return _is_strict_int(v)
+    if t == "double":
+        return _is_strict_int(v) or isinstance(v, float)
+    return isinstance(v, expected)
+
+
+def _path_exists_in_prefs(prefs: dict, key: str) -> bool:
+    """Whether ``key`` resolves to an existing leaf in ``prefs``.
+
+    Used to suppress "unknown key" warnings for prefs that Vivaldi
+    actually stores at runtime but doesn't document in
+    ``prefs_definitions.json`` (a non-trivial set, e.g.
+    ``vivaldi.tabs.vertical_tabs_enabled``).  Reaching the leaf is
+    enough; the value type is irrelevant here.
+    """
+    cur: Any = prefs
+    for part in key.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False
+        cur = cur[part]
+    return True
+
+
+def coerce_and_validate(
+    target: dict[str, Any],
+    schema: dict[str, dict] | None,
+    current_prefs: dict | None = None,
+) -> tuple[list[str], list[str]]:
+    """Mutate ``target`` to coerce friendly values, return (warnings, errors).
+
+    - Enum string -> int via ``enum_values`` mapping (the file format
+      Vivaldi actually expects on disk).  ``"left"`` -> ``1``.
+    - Type mismatch on bool/int/string/list/dict -> error string.
+    - Unknown key (not in schema AND not present in current
+      ``Preferences``) -> warning. Vivaldi has many runtime-set prefs
+      that aren't declared in ``prefs_definitions.json``; suppressing
+      the warning when the key is already present avoids false-positive
+      typo alerts on every legitimate write.
+
+    When ``schema`` is ``None`` the function is a no-op and returns
+    empty lists -- callers stay schema-optional.
+    """
+    if schema is None:
+        return [], []
+
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    for key in list(target.keys()):
+        defn = schema.get(key)
+        if defn is None:
+            if current_prefs is not None and _path_exists_in_prefs(current_prefs, key):
+                continue
+            warnings.append(
+                f"unknown setting key {key!r} (not in Vivaldi prefs schema "
+                f"and not present in Preferences; will be written as-is, "
+                f"but verify spelling)"
+            )
+            continue
+
+        t = defn.get(_TYPE_FIELD)
+        v = target[key]
+
+        if t == "enum":
+            enum_values = defn.get("enum_values") or {}
+            valid_ints = set(enum_values.values())
+            if isinstance(v, str):
+                if v in enum_values:
+                    target[key] = enum_values[v]
+                else:
+                    valid_names = ", ".join(repr(k) for k in enum_values)
+                    errors.append(
+                        f"{key}: enum value {v!r} not recognised "
+                        f"(expected one of: {valid_names})"
+                    )
+            elif _is_strict_int(v):
+                if v not in valid_ints:
+                    errors.append(
+                        f"{key}: enum int {v} out of range "
+                        f"(expected one of: {sorted(valid_ints)})"
+                    )
+            else:
+                valid_names = ", ".join(repr(k) for k in enum_values)
+                errors.append(
+                    f"{key}: enum expects a string or int "
+                    f"(one of: {valid_names}), got {type(v).__name__}"
+                )
+            continue
+
+        if not _check_simple(t, v):
+            errors.append(
+                f"{key}: schema expects {t}, got {type(v).__name__} "
+                f"(value: {v!r})"
+            )
+
+    return warnings, errors
+
+
+# --------------------------------------------------------------------------
+# Search / describe (used by CLI)
+# --------------------------------------------------------------------------
+
+def search(schema: dict[str, dict] | None, query: str) -> list[tuple[str, dict]]:
+    """Return ``[(key, def), ...]`` matching ``query`` (case-insensitive).
+
+    Matches against the dotted key, the description, and (for enums)
+    the enum value names.  Multi-word queries match if every whitespace-
+    separated token is found somewhere.  Results are sorted by key.
+    """
+    if schema is None:
+        return []
+    tokens = [t.lower() for t in query.split() if t]
+    if not tokens:
+        return []
+
+    matches: list[tuple[str, dict]] = []
+    for key, defn in schema.items():
+        haystack = key.lower()
+        desc = defn.get("description")
+        if isinstance(desc, str):
+            haystack += " " + desc.lower()
+        enum_values = defn.get("enum_values")
+        if isinstance(enum_values, dict):
+            haystack += " " + " ".join(str(k).lower() for k in enum_values)
+        if all(tok in haystack for tok in tokens):
+            matches.append((key, defn))
+    matches.sort(key=lambda kv: kv[0])
+    return matches
+
+
+def format_def(key: str, defn: dict) -> list[str]:
+    """Render a single schema entry as human-readable lines.
+
+    Used by both ``settings search`` and ``settings describe`` so the
+    output shape stays consistent.
+    """
+    lines = [key]
+    desc = defn.get("description")
+    if isinstance(desc, str) and desc:
+        lines.append(f"  description: {desc}")
+    t = defn.get(_TYPE_FIELD, "?")
+    default = defn.get("default")
+    type_line = f"  type: {t}"
+    if default is not None:
+        type_line += f"   default: {default!r}"
+    lines.append(type_line)
+    if t == "enum":
+        enum_values = defn.get("enum_values") or {}
+        pairs = ", ".join(f"{k!r}={v}" for k, v in enum_values.items())
+        lines.append(f"  values: {pairs}")
+    return lines

--- a/src/dotbrowser/vivaldi/settings.py
+++ b/src/dotbrowser/vivaldi/settings.py
@@ -1,11 +1,28 @@
-"""Vivaldi settings -- thin wrapper around shared settings logic."""
+"""Vivaldi settings -- thin wrapper that adds prefs-schema awareness.
+
+What this layer adds on top of ``_base.settings``:
+
+* ``apply`` time: enum-name strings (``"left"``) get coerced to the int
+  value Vivaldi actually stores (``1``).  Type mismatches and unknown
+  keys are surfaced before the write happens.
+* ``settings search`` and ``settings describe`` subcommands -- query
+  the prefs schema by keyword or look up a single key.
+
+Both features require ``prefs_definitions.json`` from the Vivaldi
+install directory (see ``schema.py``).  When the schema is unavailable,
+``apply`` falls back to the pre-schema behavior and the new
+subcommands print a clear "schema not found" message.
+"""
 from __future__ import annotations
 
 import argparse
+import json
+import sys
 from pathlib import Path
 
 from dotbrowser._base import settings as _base
-from dotbrowser._base.utils import Plan
+from dotbrowser._base.utils import Plan, find_preferences, load_prefs
+from dotbrowser.vivaldi import schema as _schema
 
 NAMESPACE = _base.NAMESPACE
 
@@ -23,7 +40,32 @@ diff_summary = _base.diff_summary
 
 
 def plan_apply(prefs_path: Path, prefs: dict, raw_table: object) -> Plan:
-    return _base.plan_apply("vivaldi", prefs_path, prefs, raw_table)
+    """Schema-aware variant of the shared settings ``plan_apply``.
+
+    Enum-name coercion runs *before* the base layer so all downstream
+    bookkeeping (diff, state sidecar, verify) sees the on-disk
+    representation Vivaldi actually expects.  Validation errors abort
+    here because writing them through would silently no-op at runtime
+    -- exactly the failure mode the schema layer exists to prevent.
+    """
+    extra_warnings: list[str] = []
+    if isinstance(raw_table, dict):
+        schema = _schema.load_schema()
+        if schema is not None:
+            warnings, errors = _schema.coerce_and_validate(
+                raw_table, schema, current_prefs=prefs
+            )
+            if errors:
+                sys.exit(
+                    "error: [settings] failed Vivaldi schema validation:\n  "
+                    + "\n  ".join(errors)
+                )
+            extra_warnings = warnings
+
+    plan = _base.plan_apply("vivaldi", prefs_path, prefs, raw_table)
+    if extra_warnings:
+        plan.warnings.extend(extra_warnings)
+    return plan
 
 
 def cmd_dump(args: argparse.Namespace) -> None:
@@ -34,5 +76,82 @@ def cmd_blocked(args: argparse.Namespace) -> None:
     _base.cmd_blocked("vivaldi", args)
 
 
+# --------------------------------------------------------------------------
+# Schema-backed inspection commands
+# --------------------------------------------------------------------------
+
+def _require_schema() -> dict[str, dict]:
+    schema = _schema.load_schema()
+    if schema is None:
+        sys.exit(
+            "error: Vivaldi prefs schema not found.\n"
+            "  Looked in standard install paths; set "
+            "DOTBROWSER_VIVALDI_PREFS_DEF=/path/to/prefs_definitions.json "
+            "to override."
+        )
+    return schema
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    schema = _require_schema()
+    matches = _schema.search(schema, args.query)
+    if not matches:
+        sys.exit(f"no settings match query: {args.query!r}")
+    out_lines: list[str] = []
+    for key, defn in matches[: args.limit]:
+        out_lines.extend(_schema.format_def(key, defn))
+        out_lines.append("")
+    if len(matches) > args.limit:
+        out_lines.append(
+            f"# ...{len(matches) - args.limit} more matches (use --limit to widen)"
+        )
+    sys.stdout.write("\n".join(out_lines).rstrip() + "\n")
+
+
+def cmd_describe(args: argparse.Namespace) -> None:
+    schema = _require_schema()
+    defn = _schema.lookup(schema, args.key)
+    if defn is None:
+        sys.exit(
+            f"error: key {args.key!r} not found in Vivaldi prefs schema "
+            f"(try `dotbrowser vivaldi settings search ...`)"
+        )
+
+    lines = _schema.format_def(args.key, defn)
+
+    prefs_path = find_preferences(args.profile_root, args.profile)
+    prefs = load_prefs(prefs_path)
+    cur = _get_value(prefs, _split_key(args.key))
+    if cur is _MISSING:
+        lines.append("  current: <not set>")
+    else:
+        lines.append(f"  current: {json.dumps(cur)}")
+
+    sys.stdout.write("\n".join(lines) + "\n")
+
+
 def register(subparsers: argparse._SubParsersAction) -> None:
-    _base.register("vivaldi", subparsers)
+    sub = _base.register("vivaldi", subparsers)
+
+    s = sub.add_parser(
+        "search",
+        help="search the Vivaldi prefs schema by keyword",
+    )
+    s.add_argument(
+        "query",
+        help="case-insensitive query; matches key, description, enum names",
+    )
+    s.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="max matches to print (default: 20)",
+    )
+    s.set_defaults(func=cmd_search)
+
+    d = sub.add_parser(
+        "describe",
+        help="show the schema entry for a key plus its current value",
+    )
+    d.add_argument("key", help="dotted-path key, e.g. vivaldi.tabs.bar.position")
+    d.set_defaults(func=cmd_describe)

--- a/tests/test_vivaldi_schema.py
+++ b/tests/test_vivaldi_schema.py
@@ -1,0 +1,429 @@
+"""Tests for the Vivaldi prefs-schema layer.
+
+Covers:
+
+* schema discovery via the ``DOTBROWSER_VIVALDI_PREFS_DEF`` env var
+  (the override path; the install-path candidates are exercised
+  implicitly when running on a machine with Vivaldi installed but are
+  not part of automated coverage),
+* flattening of both shapes the schema uses (nested ``vivaldi.*`` tree
+  and the chromium-style ``{kIdent: {path, type}}`` tables),
+* coercion + validation -- enum string -> int, type mismatches,
+  unknown-key warning suppression for keys already present in
+  Preferences,
+* the schema-aware ``plan_apply`` (in-process), and
+* the ``settings search`` / ``settings describe`` subcommands via the
+  CLI (subprocess so argparse wiring is real).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from dotbrowser import vivaldi as vivaldi_pkg
+from dotbrowser.vivaldi import schema as _schema
+from dotbrowser.vivaldi import settings as vsettings
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A miniature schema covering one of each shape we care about.  Real
+# prefs_definitions.json is ~25k lines; this fixture stays narrow so
+# expectations are obvious from the test source alone.
+FAKE_SCHEMA: dict = {
+    "documentation": "test",
+    "vivaldi": {
+        "tabs": {
+            "bar": {
+                "position": {
+                    "type": "enum",
+                    "enum_values": {"top": 0, "left": 1, "right": 2, "bottom": 3},
+                    "default": "top",
+                    "description": "Tab Bar Position",
+                },
+                "width": {
+                    "type": "integer",
+                    "default": 180,
+                    "description": "Vertical Tab Bar width",
+                },
+            },
+            "minimize": {
+                "type": "boolean",
+                "default": False,
+                "description": "Minimize tabs",
+            },
+        },
+    },
+    "chromium": {
+        "kAcceptLanguages": {
+            "path": "intl.accept_languages",
+            "type": "string",
+        },
+    },
+    "chromium_local": {
+        "kMemorySaverEnabled": {
+            "path": "performance_tuning.high_efficiency_mode.state",
+            "type": "integer",
+        },
+    },
+}
+
+
+@pytest.fixture
+def fake_schema(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[dict]:
+    """Point the loader at a temp ``prefs_definitions.json`` and clear cache.
+
+    The cache lives at process scope (``functools.lru_cache``) so tests
+    that swap schemas in/out have to clear it explicitly.  Yields the
+    flat ``{key: def}`` map for assertion convenience.
+    """
+    path = tmp_path / "prefs_definitions.json"
+    path.write_text(json.dumps(FAKE_SCHEMA))
+    monkeypatch.setenv("DOTBROWSER_VIVALDI_PREFS_DEF", str(path))
+    _schema.load_schema.cache_clear()
+    flat = _schema.load_schema()
+    assert flat is not None
+    yield flat
+    _schema.load_schema.cache_clear()
+
+
+@pytest.fixture
+def no_schema(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[None]:
+    """Force ``load_schema`` to return ``None`` -- env var points at a
+    nonexistent file, which short-circuits before any candidate paths.
+    """
+    missing = tmp_path / "does-not-exist.json"
+    monkeypatch.setenv("DOTBROWSER_VIVALDI_PREFS_DEF", str(missing))
+    _schema.load_schema.cache_clear()
+    assert _schema.load_schema() is None
+    yield
+    _schema.load_schema.cache_clear()
+
+
+# --------------------------------------------------------------------------
+# Loader
+# --------------------------------------------------------------------------
+
+def test_loader_flattens_both_shapes(fake_schema: dict) -> None:
+    # Vivaldi nested tree -- key prefixed with the top-level "vivaldi.".
+    assert "vivaldi.tabs.bar.position" in fake_schema
+    assert fake_schema["vivaldi.tabs.bar.position"]["type"] == "enum"
+    # Chromium-style: dotted key comes from the entry's `path` field,
+    # NOT the kIdent.
+    assert "intl.accept_languages" in fake_schema
+    assert "kAcceptLanguages" not in fake_schema
+    assert "performance_tuning.high_efficiency_mode.state" in fake_schema
+
+
+def test_loader_returns_none_when_schema_absent(no_schema: None) -> None:
+    assert _schema.load_schema() is None
+    # Lookup on None must not raise.
+    assert _schema.lookup(None, "anything") is None
+
+
+def test_loader_handles_corrupt_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bad = tmp_path / "prefs_definitions.json"
+    bad.write_text("{not valid json")
+    monkeypatch.setenv("DOTBROWSER_VIVALDI_PREFS_DEF", str(bad))
+    _schema.load_schema.cache_clear()
+    try:
+        # Loader should swallow JSON errors and treat schema as missing.
+        assert _schema.load_schema() is None
+    finally:
+        _schema.load_schema.cache_clear()
+
+
+# --------------------------------------------------------------------------
+# Coercion + validation
+# --------------------------------------------------------------------------
+
+def test_enum_string_coerced_to_int(fake_schema: dict) -> None:
+    target = {"vivaldi.tabs.bar.position": "left"}
+    warnings, errors = _schema.coerce_and_validate(target, fake_schema)
+    assert errors == []
+    assert warnings == []
+    # The mutation is the whole point: downstream sees the int Vivaldi
+    # actually stores on disk.
+    assert target == {"vivaldi.tabs.bar.position": 1}
+
+
+def test_enum_int_in_range_passes(fake_schema: dict) -> None:
+    target = {"vivaldi.tabs.bar.position": 2}
+    warnings, errors = _schema.coerce_and_validate(target, fake_schema)
+    assert errors == []
+    assert warnings == []
+    assert target == {"vivaldi.tabs.bar.position": 2}
+
+
+def test_enum_unknown_string_errors(fake_schema: dict) -> None:
+    target = {"vivaldi.tabs.bar.position": "middle"}
+    _, errors = _schema.coerce_and_validate(target, fake_schema)
+    assert len(errors) == 1
+    assert "'middle' not recognised" in errors[0]
+    assert "'top'" in errors[0] and "'bottom'" in errors[0]
+
+
+def test_enum_int_out_of_range_errors(fake_schema: dict) -> None:
+    target = {"vivaldi.tabs.bar.position": 9}
+    _, errors = _schema.coerce_and_validate(target, fake_schema)
+    assert len(errors) == 1
+    assert "out of range" in errors[0]
+
+
+def test_type_mismatch_boolean(fake_schema: dict) -> None:
+    target = {"vivaldi.tabs.minimize": "yes"}
+    _, errors = _schema.coerce_and_validate(target, fake_schema)
+    assert len(errors) == 1
+    assert "expects boolean" in errors[0]
+
+
+def test_type_mismatch_integer(fake_schema: dict) -> None:
+    target = {"vivaldi.tabs.bar.width": "180"}
+    _, errors = _schema.coerce_and_validate(target, fake_schema)
+    assert len(errors) == 1
+    assert "expects integer" in errors[0]
+
+
+def test_unknown_key_warns_when_not_in_prefs(fake_schema: dict) -> None:
+    target = {"vivaldi.totally.unknown": True}
+    warnings, errors = _schema.coerce_and_validate(target, fake_schema, current_prefs={})
+    assert errors == []
+    assert len(warnings) == 1
+    assert "unknown setting key" in warnings[0]
+    # Value is left intact -- "warn but write" is the contract.
+    assert target == {"vivaldi.totally.unknown": True}
+
+
+def test_unknown_key_silent_when_present_in_prefs(fake_schema: dict) -> None:
+    """``vivaldi.tabs.vertical_tabs_enabled`` is a real, runtime-set Vivaldi
+    pref that's *not* in prefs_definitions.json.  Warning would be a
+    false positive on every apply, so we suppress when the path
+    already resolves in ``Preferences``.
+    """
+    prefs = {"vivaldi": {"tabs": {"vertical_tabs_enabled": False}}}
+    target = {"vivaldi.tabs.vertical_tabs_enabled": True}
+    warnings, errors = _schema.coerce_and_validate(target, fake_schema, current_prefs=prefs)
+    assert errors == []
+    assert warnings == []
+
+
+def test_schema_none_is_noop() -> None:
+    target = {"x": "y", "vivaldi.tabs.bar.position": "left"}
+    snapshot = dict(target)
+    warnings, errors = _schema.coerce_and_validate(target, None)
+    assert errors == []
+    assert warnings == []
+    assert target == snapshot
+
+
+def test_chromium_key_validated(fake_schema: dict) -> None:
+    target = {"intl.accept_languages": 5}
+    _, errors = _schema.coerce_and_validate(target, fake_schema)
+    assert len(errors) == 1
+    assert "expects string" in errors[0]
+
+
+# --------------------------------------------------------------------------
+# Search + describe API
+# --------------------------------------------------------------------------
+
+def test_search_matches_key_and_description(fake_schema: dict) -> None:
+    matches = _schema.search(fake_schema, "tab bar position")
+    assert ("vivaldi.tabs.bar.position", fake_schema["vivaldi.tabs.bar.position"]) in matches
+
+
+def test_search_matches_enum_value_name(fake_schema: dict) -> None:
+    # "bottom" appears only in enum_values, not in the key or description.
+    matches = _schema.search(fake_schema, "bottom")
+    keys = [k for k, _ in matches]
+    assert "vivaldi.tabs.bar.position" in keys
+
+
+def test_search_no_match_returns_empty(fake_schema: dict) -> None:
+    assert _schema.search(fake_schema, "nonexistentterm") == []
+
+
+def test_format_def_renders_enum(fake_schema: dict) -> None:
+    defn = fake_schema["vivaldi.tabs.bar.position"]
+    lines = _schema.format_def("vivaldi.tabs.bar.position", defn)
+    blob = "\n".join(lines)
+    assert "vivaldi.tabs.bar.position" in blob
+    assert "type: enum" in blob
+    assert "'top'=0" in blob and "'left'=1" in blob
+
+
+# --------------------------------------------------------------------------
+# Schema-aware plan_apply
+# --------------------------------------------------------------------------
+
+def _vivaldi_profile(tmp_path: Path) -> Path:
+    profile = tmp_path / "Default"
+    profile.mkdir()
+    prefs = {"vivaldi": {"tabs": {"bar": {}}}}
+    (profile / "Preferences").write_text(json.dumps(prefs))
+    return tmp_path
+
+
+def test_plan_apply_coerces_enum(fake_schema: dict, tmp_path: Path) -> None:
+    profile_root = _vivaldi_profile(tmp_path)
+    prefs_path = profile_root / "Default" / "Preferences"
+    prefs = json.loads(prefs_path.read_text())
+
+    raw = {"vivaldi.tabs.bar.position": "left"}
+    plan = vsettings.plan_apply(prefs_path, prefs, raw)
+
+    # The diff and the apply both see the coerced int.
+    assert any("= 1" in line for line in plan.diff_lines), plan.diff_lines
+    assert raw["vivaldi.tabs.bar.position"] == 1
+
+
+def test_plan_apply_aborts_on_invalid_enum(
+    fake_schema: dict, tmp_path: Path
+) -> None:
+    profile_root = _vivaldi_profile(tmp_path)
+    prefs_path = profile_root / "Default" / "Preferences"
+    prefs = json.loads(prefs_path.read_text())
+
+    raw = {"vivaldi.tabs.bar.position": "middle"}
+    with pytest.raises(SystemExit) as exc:
+        vsettings.plan_apply(prefs_path, prefs, raw)
+    msg = str(exc.value)
+    assert "schema validation" in msg
+    assert "'middle'" in msg
+
+
+def test_plan_apply_propagates_warnings(
+    fake_schema: dict, tmp_path: Path
+) -> None:
+    profile_root = _vivaldi_profile(tmp_path)
+    prefs_path = profile_root / "Default" / "Preferences"
+    prefs = json.loads(prefs_path.read_text())
+
+    raw = {"vivaldi.totally.unknown": True}
+    plan = vsettings.plan_apply(prefs_path, prefs, raw)
+    assert any("unknown setting key" in w for w in plan.warnings)
+
+
+def test_plan_apply_falls_back_when_schema_absent(
+    no_schema: None, tmp_path: Path
+) -> None:
+    profile_root = _vivaldi_profile(tmp_path)
+    prefs_path = profile_root / "Default" / "Preferences"
+    prefs = json.loads(prefs_path.read_text())
+
+    # Schema missing -> no validation, no coercion, no warnings; writes
+    # whatever the user gave us.  Mirrors pre-schema behavior so users
+    # without the schema file aren't worse off.
+    raw = {"vivaldi.tabs.bar.position": "left"}
+    plan = vsettings.plan_apply(prefs_path, prefs, raw)
+    assert any("'left'" in line or '"left"' in line for line in plan.diff_lines)
+    assert plan.warnings == []
+
+
+# --------------------------------------------------------------------------
+# CLI: search + describe
+# --------------------------------------------------------------------------
+
+def _run_cli(
+    profile_root: Path, schema_path: Path | None, *extra: str
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+    if schema_path is not None:
+        env["DOTBROWSER_VIVALDI_PREFS_DEF"] = str(schema_path)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "dotbrowser",
+            "vivaldi",
+            "--profile-root",
+            str(profile_root),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_cli_search_finds_key(tmp_path: Path) -> None:
+    schema_path = tmp_path / "prefs_definitions.json"
+    schema_path.write_text(json.dumps(FAKE_SCHEMA))
+    profile = _vivaldi_profile(tmp_path)
+    r = _run_cli(profile, schema_path, "settings", "search", "tab bar position")
+    assert r.returncode == 0, r.stderr
+    assert "vivaldi.tabs.bar.position" in r.stdout
+    assert "type: enum" in r.stdout
+    assert "'left'=1" in r.stdout
+
+
+def test_cli_search_no_match_exits_nonzero(tmp_path: Path) -> None:
+    schema_path = tmp_path / "prefs_definitions.json"
+    schema_path.write_text(json.dumps(FAKE_SCHEMA))
+    profile = _vivaldi_profile(tmp_path)
+    r = _run_cli(profile, schema_path, "settings", "search", "xyzzyqwerty")
+    assert r.returncode == 1
+    assert "no settings match" in r.stderr
+
+
+def test_cli_describe_shows_current_value(tmp_path: Path) -> None:
+    schema_path = tmp_path / "prefs_definitions.json"
+    schema_path.write_text(json.dumps(FAKE_SCHEMA))
+    profile = tmp_path
+    (profile / "Default").mkdir()
+    (profile / "Default" / "Preferences").write_text(
+        json.dumps({"vivaldi": {"tabs": {"bar": {"position": 1}}}})
+    )
+    r = _run_cli(profile, schema_path, "settings", "describe", "vivaldi.tabs.bar.position")
+    assert r.returncode == 0, r.stderr
+    assert "current: 1" in r.stdout
+
+
+def test_cli_describe_unknown_key_errors(tmp_path: Path) -> None:
+    schema_path = tmp_path / "prefs_definitions.json"
+    schema_path.write_text(json.dumps(FAKE_SCHEMA))
+    profile = _vivaldi_profile(tmp_path)
+    r = _run_cli(profile, schema_path, "settings", "describe", "nonexistent.key")
+    assert r.returncode == 1
+    assert "not found" in r.stderr
+
+
+def test_cli_apply_coerces_and_writes_int(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Full CLI round-trip: TOML with ``"left"`` lands in Preferences as ``1``."""
+    schema_path = tmp_path / "prefs_definitions.json"
+    schema_path.write_text(json.dumps(FAKE_SCHEMA))
+    profile_root = _vivaldi_profile(tmp_path)
+    cfg = tmp_path / "settings.toml"
+    cfg.write_text('[settings]\n"vivaldi.tabs.bar.position" = "left"\n')
+
+    monkeypatch.setattr(vivaldi_pkg, "vivaldi_running", lambda: False)
+
+    args = argparse.Namespace(
+        profile_root=profile_root,
+        profile="Default",
+        config=cfg,
+        dry_run=False,
+        kill_browser=False,
+        expect_sha256=None,
+        allow_http=False,
+    )
+    monkeypatch.setenv("DOTBROWSER_VIVALDI_PREFS_DEF", str(schema_path))
+    _schema.load_schema.cache_clear()
+    try:
+        vivaldi_pkg.cmd_apply(args)
+    finally:
+        _schema.load_schema.cache_clear()
+
+    final = json.loads((profile_root / "Default" / "Preferences").read_text())
+    assert final["vivaldi"]["tabs"]["bar"]["position"] == 1


### PR DESCRIPTION
## Summary

Vivaldi stores enum prefs as integers on disk (e.g. tab bar position `"left"` -> `1`) but its UI accepts the friendly names. Writing the string through dotbrowser succeeded silently in v0.5.x, then Vivaldi quietly fell back to the default at runtime because the JSON type was wrong. This PR makes ``vivaldi/settings`` schema-aware so this class of bug fails loud.

- **Apply-time coercion + validation.** Read Vivaldi's bundled `prefs_definitions.json` (Brave/Edge/Chrome ship no comparable file), coerce enum-name strings to ints, abort on type mismatches / out-of-range enum values before any write. Unknown keys warn (still written), with the warning suppressed when the path already resolves in `Preferences` -- Vivaldi has many runtime-set prefs (e.g. ``vivaldi.tabs.vertical_tabs_enabled``) that aren't declared in the schema, and a naive warning would be a false positive on every legitimate write.
- **Two new inspection subcommands** that consume the same flattened schema:
  ```
  dotbrowser vivaldi settings search "tab bar position"
  dotbrowser vivaldi settings describe vivaldi.tabs.bar.position
  ```
- **Graceful fallback.** Schema discovery probes standard install paths per OS and honours `DOTBROWSER_VIVALDI_PREFS_DEF` for explicit override (also used by the test fixture). When the schema can't be located, `apply` falls back to the pre-schema behaviour (write blindly) and the new subcommands print "schema not found" rather than crashing.
- **Minimal `_base` change.** `_base.settings.register` now returns the inner `add_subparsers` action so Vivaldi can extend it with `search` / `describe`. Brave / Edge / Chrome ignore the return value -- behaviour unchanged.

## Files

- `src/dotbrowser/vivaldi/schema.py` (new) -- loader (lru_cached), flattening of both shapes (`vivaldi.*` nested tree and `chromium`/`chromium_local` `{kIdent: {path, type}}` tables), `coerce_and_validate`, `search`, `format_def`.
- `src/dotbrowser/vivaldi/settings.py` -- thin wrapper now does coerce/validate before delegating, plus `cmd_search` / `cmd_describe` registered next to `dump` / `blocked`.
- `src/dotbrowser/_base/settings.py` -- `register` returns the inner subparsers (one-line behavioural change for callers that want it; old callers ignore the return value).
- `tests/test_vivaldi_schema.py` (new, 26 cases) -- loader, coercion paths, schema-missing fallback, `plan_apply` integration (warnings flow through `Plan.warnings`), and CLI subcommand subprocess tests.
- `CLAUDE.md` -- documents the new commands, the schema layer in the architecture section, and the new test file.

## Test plan

- [x] `pytest -q` -> 242 passed, 4 skipped (pre-existing skips, no new ones).
- [x] Manual end-to-end on a real profile: `apply` with `"vivaldi.tabs.bar.position" = "left"` lands on disk as int `1`; bad enum string aborts with `enum value 'middle' not recognised (expected one of: 'top', 'left', 'right', 'bottom')`; `search "tab bar position"` finds the key; `describe` shows current stored value.
- [x] Schema-missing path: setting `DOTBROWSER_VIVALDI_PREFS_DEF` to a nonexistent file makes `apply` skip validation (covered by `test_plan_apply_falls_back_when_schema_absent`).