### PR TITLE
fix(vivaldi): write [pwa] policy to /etc/chromium/policies on Linux

### DIFF
--- a/examples/vivaldi/pwa.toml
+++ b/examples/vivaldi/pwa.toml
@@ -7,7 +7,11 @@
 #
 # Two important differences from [shortcuts] / [settings]:
 #   - REQUIRES SUDO. The policy file is root-owned:
-#       Linux: /etc/vivaldi/policies/managed/dotbrowser-pwa.json
+#       Linux: /etc/chromium/policies/managed/dotbrowser-pwa.json
+#              (Vivaldi compiles in /etc/chromium/policies as its
+#              managed-policy search dir on Linux, so chromium-browser
+#              and Vivaldi share the directory; the filename keeps our
+#              entry namespaced.)
 #       macOS: /Library/Managed Preferences/com.vivaldi.Vivaldi.plist
 #   - REQUIRES VIVALDI RESTART. Policies load at startup only — pass
 #     `--kill-browser` (`-k`) to apply immediately.

--- a/src/dotbrowser/vivaldi/pwa.py
+++ b/src/dotbrowser/vivaldi/pwa.py
@@ -12,9 +12,18 @@ from dotbrowser._base.utils import Plan, find_preferences
 NAMESPACE = _base.NAMESPACE
 POLICY_KEY = _base.POLICY_KEY
 
+# Vivaldi on Linux compiles its managed-policy search path to
+# ``/etc/chromium/policies`` (verifiable with
+# ``strings /opt/vivaldi/vivaldi-bin | grep '/etc/.*polic'`` -- the only
+# match), so a file at the ``/etc/vivaldi/...`` path many users assume
+# from the brand name is silently ignored.  This means our policy
+# shares a directory with chromium-browser if both are installed; the
+# ``dotbrowser-pwa.json`` filename keeps it namespaced.  macOS reads
+# from the Vivaldi-specific bundle plist; Windows uses a
+# Vivaldi-specific registry key.
 _PWA_CONFIG = _base.PwaConfig(
     browser_name="vivaldi",
-    linux_policy_path="/etc/vivaldi/policies/managed/dotbrowser-pwa.json",
+    linux_policy_path="/etc/chromium/policies/managed/dotbrowser-pwa.json",
     macos_plist_path="/Library/Managed Preferences/com.vivaldi.Vivaldi.plist",
     windows_registry_key=r"Software\Policies\Vivaldi",
 )

--- a/tests/test_vivaldi_logic.py
+++ b/tests/test_vivaldi_logic.py
@@ -243,3 +243,15 @@ def test_pwa_validate_rejects_non_https() -> None:
         pwa._validate_table({"urls": ["javascript:alert(1)"]})
     with pytest.raises(SystemExit, match="must start with https://"):
         pwa._validate_table({"urls": ["http://example.com/"]})
+
+
+def test_pwa_linux_policy_path_lives_in_chromium_dir() -> None:
+    """Vivaldi compiles ``/etc/chromium/policies`` (not
+    ``/etc/vivaldi/policies``) as its managed-policy search path on
+    Linux -- a file written to the brand-named directory is silently
+    ignored.  Lock the corrected path so a future refactor can't
+    revert it without the test screaming.
+    """
+    assert pwa._PWA_CONFIG.linux_policy_path.startswith(
+        "/etc/chromium/policies/managed/"
+    ), pwa._PWA_CONFIG.linux_policy_path


### PR DESCRIPTION
## Summary

Vivaldi on Linux compiles its managed-policy search path to `/etc/chromium/policies`, not `/etc/vivaldi/policies` as the brand-named directory would suggest.

**Repro:**

```
$ strings /opt/vivaldi/vivaldi-bin | grep '/etc/.*polic'
/etc/chromium/policies   # the only match
```

**Result of the bug:** a file at `/etc/vivaldi/policies/managed/dotbrowser-pwa.json` was being written successfully (sudo prompt, JSON, root-owned, the works) and then silently ignored by Vivaldi at startup. PWAs in the `[pwa]` table never installed -- the apply reported success, the policy file existed and was valid, but Vivaldi never read it.

## Fix

Switch the Linux path in `vivaldi/pwa._PWA_CONFIG` from `/etc/vivaldi/policies/managed/...` to `/etc/chromium/policies/managed/...`.

**Side-effect:** if chromium-browser is also installed, both browsers will pick up the same policy file -- which is how Vivaldi designed it on Linux, not something we can avoid. The `dotbrowser-pwa.json` filename keeps the entry namespaced.

**Out of scope:** macOS (`/Library/Managed Preferences/com.vivaldi.Vivaldi.plist`, Vivaldi-specific bundle plist) and Windows (`Software\Policies\Vivaldi`, Vivaldi-specific registry key) are correct and unchanged.

## Files

- `src/dotbrowser/vivaldi/pwa.py` -- one-line path change, with a comment explaining why so a future refactor can't quietly revert.
- `tests/test_vivaldi_logic.py` -- regression test (`test_pwa_linux_policy_path_lives_in_chromium_dir`) that pins the path prefix.
- `examples/vivaldi/pwa.toml` -- updated header comment so users know which directory the policy actually lands in.

## Test plan

- [x] `pytest -q` -> 243 passed, 4 skipped (one new test).
- [x] Verified empirically on this machine: existing `/etc/vivaldi/policies/managed/dotbrowser-pwa.json` was a valid 1.4KB file, but `chrome://policy` (Vivaldi) showed nothing and PWAs never installed -- exactly the symptom this PR fixes. Re-applying after the fix will write to the chromium dir; users can verify via `vivaldi://policy` after restart.